### PR TITLE
Avoid empty chat message

### DIFF
--- a/libs/ktem/ktem/pages/chat/__init__.py
+++ b/libs/ktem/ktem/pages/chat/__init__.py
@@ -445,6 +445,13 @@ class ChatPage(BasePage):
             state[pipeline.get_info()["id"]] = reasoning_state["pipeline"]
             yield chat_history + [(chat_input, text or msg_placeholder)], refs, state
 
+        if not text:
+            empty_msg = getattr(
+                flowsettings, "KH_CHAT_EMPTY_MSG_PLACEHOLDER", "(Sorry, I don't know)"
+            )
+            print(f"Generate nothing: {empty_msg}")
+            yield chat_history + [(chat_input, text or empty_msg)], refs, state
+
     def regen_fn(self, conversation_id, chat_history, settings, state, *selecteds):
         """Regen function"""
         if not chat_history:


### PR DESCRIPTION
Sometimes due to errors, the agent generates empty string, and as a result, an empty string shows up on the UI. This behavior confuses users in that (1) they don't know if the pipeline finishes, (2) they don't know if there's error, (3) what they should do next.

As a result, in the application side, we avoid showing empty string to the user, and use a placeholder instead.