### PR TITLE
feat: reduce docker image size by removing unnecessary cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,17 @@ FROM python:3.10-slim as base_image
 # libxext6 \
 # ffmpeg \
 
-RUN apt update -qqy \
-  && apt install -y \
-  ssh git \
-  gcc g++ \
-  poppler-utils \
-  libpoppler-dev \
-  && \
-  apt-get clean && \
-  apt-get autoremove
+RUN apt-get update -qqy && \
+    apt-get install -y --no-install-recommends \
+      ssh \ 
+      git \ 
+      gcc \
+      g++ \
+      poppler-utils \
+      libpoppler-dev \
+    && apt-get clean \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -29,9 +31,9 @@ WORKDIR /app
 FROM base_image as dev
 
 COPY . /app
-RUN --mount=type=ssh pip install -e "libs/kotaemon[all]"
-RUN --mount=type=ssh pip install -e "libs/ktem"
-RUN pip install graphrag future
-RUN pip install "pdfservices-sdk@git+https://github.com/niallcm/pdfservices-python-sdk.git@bump-and-unfreeze-requirements"
+RUN --mount=type=ssh pip install --no-cache-dir -e "libs/kotaemon[all]" \
+    && pip install --no-cache-dir -e "libs/ktem" \
+    && pip install --no-cache-dir graphrag future \
+    && pip install --no-cache-dir "pdfservices-sdk@git+https://github.com/niallcm/pdfservices-python-sdk.git@bump-and-unfreeze-requirements"
 
 ENTRYPOINT ["gradio", "app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ FROM python:3.10-slim as base_image
 
 RUN apt-get update -qqy && \
     apt-get install -y --no-install-recommends \
-      ssh \ 
-      git \ 
+      ssh \
+      git \
       gcc \
       g++ \
       poppler-utils \


### PR DESCRIPTION
## Description
- Use `apt-get` instead of `apt` since it is meant for interactive usage.
- Reduced uncompressed Docker image size from ~3.6GB to ~2GB.
  - Removes the package lists downloaded by apt-get update.
  - Prevents pip from saving downloaded package files in its cache directory, which is not needed in Docker context.

## Type of change

- [ ] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
