### PR TITLE
fix: GraphRAG does not respect .env #191

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,7 @@ LOCAL_MODEL=llama3.1:8b
 LOCAL_MODEL_EMBEDDINGS=nomic-embed-text
 
 # settings for GraphRAG
+# NOTES: currently, only OpenAI models are supported. Azure OpenAI and Ollama are not supported yet.
 GRAPHRAG_API_KEY=openai_key
 GRAPHRAG_LLM_MODEL=gpt-4o-mini
 GRAPHRAG_EMBEDDING_MODEL=text-embedding-3-small


### PR DESCRIPTION
## Description

- Fixes #191
  - GraphRAG init command does not respect env vars `GRAPHRAG_LLM_MODEL` and `GRAPHRAG_EMBEDDING_MODEL` and always use gpt-4-turbo and text-embedding-3-small as default, which is current GraphRAG's behaviour.
  - If env vars above are set, This PR makes a copy of original GraphRAG's settings.yaml as backup and change settings.yaml to use the models defined by env vars in indexing phase.

NOTES: This is a **PARTIAL** fix. This fix works for OpenAI models only, not for Azure OpenAI and Ollama yet.

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.