### PR TITLE
build: add linux/arm to docker-build workflow

### DIFF
--- a/.github/workflows/build-push-docker.yaml
+++ b/.github/workflows/build-push-docker.yaml
@@ -27,6 +27,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
+          - linux/arm64
     steps:
       - name: Set repository and image name
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -qqy && \
       libpoppler-dev \
       unzip \
       curl \
+      cargo \
     && apt-get clean \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Now each release also builds and pushes an ARM version of the dockerfile

## Description

- Added `linux/arm` to the platform matrix of the Docker image build process
- Tested it locally on my MacBook M1 with `docker build --platform linux/arm64 -t taprosoft/kotaemon:arm64 .`
- Ran the built image using 
```shell 
docker run \
-e GRADIO_SERVER_NAME=0.0.0.0 \
-e GRADIO_SERVER_PORT=7860 \
-p 7860:7860 -it --rm \
taprosoft/kotaemon:arm64
```
- I did not verify any RAG functionality

This PR is potentially, partially in conflict with the following one (https://github.com/Cinnamon/kotaemon/pull/219), due to the `rust` dependency being added there as well, and here. 

## Type of change

- [x] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
