### PR TITLE
fix: trigger auto push docker on release

### DIFF
--- a/.github/workflows/auto-bump-and-release.yaml
+++ b/.github/workflows/auto-bump-and-release.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           files: kotaemon-app.zip
           fail_on_unmatched_files: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WRITE_GITHUB_TOKEN }}
           generate_release_notes: true
           tag_name: ${{ steps.update-version.outputs.new_tag }}
           make_latest: true


### PR DESCRIPTION
## Description

- According to the github action doc, https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow. When the action is triggered by secrets.GITHUB_TOKEN. the following action because they fear it will cause accidentally creating recursive workflow runs.
- Change the secrets.GITHUB_TOKEN in the bump release to another token (which need to have enough permission: write, ...). In this PR it is ${{ secrets.WRITE_GITHUB_TOKEN }}

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
