### PR TITLE
fix: add PDFJS download to Windows setup

### DIFF
--- a/libs/ktem/ktem/app.py
+++ b/libs/ktem/ktem/app.py
@@ -49,8 +49,11 @@ class BaseApp:
             self._js = self._js.replace("KH_APP_VERSION", self.app_version)
         with (dir_assets / "js" / "pdf_viewer.js").open() as fi:
             self._pdf_view_js = fi.read()
+            # workaround for Windows path
+            pdf_js_dist_dir = str(PDFJS_PREBUILT_DIR).replace("\\", "\\\\")
             self._pdf_view_js = self._pdf_view_js.replace(
-                "PDFJS_PREBUILT_DIR", str(PDFJS_PREBUILT_DIR)
+                "PDFJS_PREBUILT_DIR",
+                pdf_js_dist_dir,
             )
 
         self._favicon = str(dir_assets / "img" / "favicon.svg")


### PR DESCRIPTION
## Description

- Add PDFJS setup process in Windows setup
- Fix diskcache issues which prevent Windows setup to work in some machines

## Type of change

- [ ] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
