### PR TITLE
feat: pass selfhosted embeddings to graphrag

### DIFF
--- a/libs/ktem/ktem/index/file/graph/graph_index.py
+++ b/libs/ktem/ktem/index/file/graph/graph_index.py
@@ -30,6 +30,7 @@ class GraphRAGIndex(FileIndex):
             GraphRAGRetrieverPipeline(
                 file_ids=file_ids,
                 Index=self._resources["Index"],
+                index_settings=self.config,
             )
         ]
 

--- a/libs/ktem/ktem/index/file/graph/pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/pipelines.py
@@ -236,13 +236,13 @@ class GraphRAGRetrieverPipeline(BaseFileIndexRetriever):
             self.index_settings.get("embedding", embedding_models_manager.get_default_name())]
         # embedding_model = os.getenv("GRAPHRAG_EMBEDDING_MODEL")
         text_embedder = OpenAIEmbedding(
-             api_key=kotaemonEmbeddings.api_key,
-             api_base=kotaemonEmbeddings.base_url,
-             api_type=OpenaiApiType.OpenAI,
-             model=kotaemonEmbeddings.model,
-             deployment_name=kotaemonEmbeddings.model,
-             max_retries=kotaemonEmbeddings.max_retries if kotaemonEmbeddings.max_retries is not None else openai.DEFAULT_MAX_RETRIES,
-         )
+            api_key=kotaemonEmbeddings.api_key,
+            api_base=kotaemonEmbeddings.base_url,
+            api_type=OpenaiApiType.OpenAI,
+            model=kotaemonEmbeddings.model,
+            deployment_name=kotaemonEmbeddings.model,
+            max_retries=kotaemonEmbeddings.max_retries if kotaemonEmbeddings.max_retries is not None else openai.DEFAULT_MAX_RETRIES,
+        )
         token_encoder = tiktoken.get_encoding("cl100k_base")
 
         context_builder = LocalSearchMixedContext(


### PR DESCRIPTION
## Description

- Just a demo how to pass self-hosted openai embeddings via admin settings to graphrag search
- not yet fixes #212  

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
