### PR TITLE
fix: change column type to string for relation_type

### DIFF
--- a/libs/ktem/ktem/index/file/index.py
+++ b/libs/ktem/ktem/index/file/index.py
@@ -115,7 +115,7 @@ class FileIndex(BaseIndex):
                 "id": Column(Integer, primary_key=True, autoincrement=True),
                 "source_id": Column(String),
                 "target_id": Column(String),
-                "relation_type": Column(Integer),
+                "relation_type": Column(String),
                 "user": Column(Integer, default=1),
             },
         )

--- a/scripts/migrate/migrate_chroma_db.py
+++ b/scripts/migrate/migrate_chroma_db.py
@@ -83,7 +83,7 @@ def _init_resource(private: bool = True, id: int = 1):
             "id": Column(Integer, primary_key=True, autoincrement=True),
             "source_id": Column(String),
             "target_id": Column(String),
-            "relation_type": Column(Integer),
+            "relation_type": Column(String),
             "user": Column(Integer, default=1),
         },
     )


### PR DESCRIPTION
## Description

- The column type (`relation_type`) is set to Integer, which causes problems in non-SQLite databases as the appropriate value is not stored when deleting entries
- Fixes #271 

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
