### PR TITLE
solve the graphRAG run with ollama

### DIFF
--- a/libs/ktem/ktem/index/file/graph/pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/pipelines.py
@@ -231,7 +231,7 @@ class GraphRAGRetrieverPipeline(BaseFileIndexRetriever):
         embedding_model = os.getenv("GRAPHRAG_EMBEDDING_MODEL")
         text_embedder = OpenAIEmbedding(
             api_key=os.getenv("OPENAI_API_KEY"),
-            api_base=None,
+            api_base=os.getenv("GRAPHRAG_API_BASE"),
             api_type=OpenaiApiType.OpenAI,
             model=embedding_model,
             deployment_name=embedding_model,


### PR DESCRIPTION
## Description

- graphRAG run with ollama locally, GraphRAGRetrieverPipeline should get the api_base url, but now it is none, it will faild with
`Error embedding chunk {'OpenAIEmbedding': "Error code: `
- Fixes # (212)

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
