### PR TITLE
ci: disable commitlint

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -44,6 +44,7 @@ jobs:
           delete: true
 
   commitlint:
+    if: false # Disable this job for now
     name: Validate commit messages
     runs-on: ubuntu-latest
     permissions: write-all


### PR DESCRIPTION
## Description

- I turn off the commitlint job because it is too strict for contributors to follow.

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
