### PR TITLE
feat: tweak the 'Chat suggestion' feature to tie it to conversations

### DIFF
--- a/flowsettings.py
+++ b/flowsettings.py
@@ -63,6 +63,7 @@ os.environ["HF_HUB_CACHE"] = str(KH_APP_DATA_DIR / "huggingface")
 KH_DOC_DIR = this_dir / "docs"
 
 KH_MODE = "dev"
+KH_FEATURE_CHAT_SUGGESTION = config("KH_FEATURE_CHAT_SUGGESTION", default=False)
 KH_FEATURE_USER_MANAGEMENT = config(
     "KH_FEATURE_USER_MANAGEMENT", default=True, cast=bool
 )

--- a/libs/ktem/ktem/db/base_models.py
+++ b/libs/ktem/ktem/db/base_models.py
@@ -34,7 +34,7 @@ class BaseConversation(SQLModel):
 
     is_public: bool = Field(default=False)
 
-    # contains messages + current files
+    # contains messages + current files + chat_suggestions
     data_source: dict = Field(default={}, sa_column=Column(JSON))
 
     date_created: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)

--- a/libs/ktem/ktem/reasoning/prompt_optimization/suggest_followup_chat.py
+++ b/libs/ktem/ktem/reasoning/prompt_optimization/suggest_followup_chat.py
@@ -1,0 +1,45 @@
+import logging
+
+from ktem.llms.manager import llms
+
+from kotaemon.base import AIMessage, BaseComponent, Document, HumanMessage, Node
+from kotaemon.llms import ChatLLM, PromptTemplate
+
+logger = logging.getLogger(__name__)
+
+
+class SuggestFollowupQuesPipeline(BaseComponent):
+    """Suggest a list of follow-up questions based on the chat history."""
+
+    llm: ChatLLM = Node(default_callback=lambda _: llms.get_default())
+    SUGGEST_QUESTIONS_PROMPT_TEMPLATE = (
+        "Based on the chat history above. "
+        "your task is to generate 3 to 5 relevant follow-up questions. "
+        "These questions should be simple, clear, "
+        "and designed to guide the conversation further. "
+        "Ensure that the questions are open-ended to encourage detailed responses. "
+        "Respond in JSON format with 'questions' key. "
+        "Answer using the language {lang} same as the question. "
+        "If the question uses Chinese, the answer should be in Chinese.\n"
+    )
+    prompt_template: str = SUGGEST_QUESTIONS_PROMPT_TEMPLATE
+    extra_prompt: str = """Example of valid response:
+```json
+{
+    "questions": ["the weather is good", "what's your favorite city"]
+}
+```"""
+    lang: str = "English"
+
+    def run(self, chat_history: list[tuple[str, str]]) -> Document:
+        prompt_template = PromptTemplate(self.prompt_template)
+        prompt = prompt_template.populate(lang=self.lang) + self.extra_prompt
+
+        messages = []
+        for human, ai in chat_history[-3:]:
+            messages.append(HumanMessage(content=human))
+            messages.append(AIMessage(content=ai))
+
+        messages.append(HumanMessage(content=prompt))
+
+        return self.llm(messages)


### PR DESCRIPTION
## Description

- The original 'Chat Suggestion' module only support setting initial values in a configuration file. LLM chat suggestion generation has been added to the new feat module.
- The content of the 'Chat Suggestion' module is bound to the session and stored in the database

## Type of change

- [x] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ]  I have performed tests.
- [x] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] The feature is well documented.