### PR TITLE
feat: GraphRAG integration update 

### DIFF
--- a/libs/ktem/ktem/index/file/graph/pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/pipelines.py
@@ -177,15 +177,8 @@ class GraphRAGRetrieverPipeline(BaseFileIndexRetriever):
 
         root_path, _ = prepare_graph_index_path(graph_id)
         output_path = root_path / "output"
-        child_paths = sorted(
-            list(output_path.iterdir()), key=lambda x: x.stem, reverse=True
-        )
 
-        # get the latest child path
-        assert child_paths, "GraphRAG index output not found"
-        latest_child_path = Path(child_paths[0]) / "artifacts"
-
-        INPUT_DIR = latest_child_path
+        INPUT_DIR = output_path
         LANCEDB_URI = str(INPUT_DIR / "lancedb")
         COMMUNITY_REPORT_TABLE = "create_final_community_reports"
         ENTITY_TABLE = "create_final_nodes"


### PR DESCRIPTION
update output path logic since GraphRAG has changed the storage configure value.

## Description

The change here is related to a setting in GraphRAG setting.yaml. In the old version of GraphRAG's setting.yaml, this setting is like this

```
storage:
  type: file # or blob
  base_dir: "output/${timestamp}/artifacts" 
```

Note that in the value of **base_dir**, there is a **${timestamp}** and **artifacts** . 
But in the new version of GraphRAG, this setting has been changed to this

```
storage:
  type: file # or blob
  base_dir: "output"
```

Here, **base_dir** only retains **output**, **${timestamp}** and **artifacts** are no longer there. 

This change has caused an error in the GraphRAG query in Kotaemon when a user upgrades/installs to the latest version of GraphRAG. 

- Fixes #367  

## Type of change

- [x] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
