### PR TITLE
fix: pin `python-multipart` version for `gradio<5` to avoid yanking issues when building docker

### DIFF
--- a/libs/ktem/pyproject.toml
+++ b/libs/ktem/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "sqlmodel>=0.0.16,<0.1",
     "tiktoken>=0.6.0,<1",
     "gradio>=4.31.0,<5",
+    "python-multipart==0.0.12", # required for gradio, pinning to avoid yanking issues with micropip (fixed in gradio >= 5.4.0)
     "markdown>=3.6,<4",
 ]
 authors = [


### PR DESCRIPTION
## Description

- Fix #434 
- Gradio issues: https://github.com/gradio-app/gradio/issues/9774

*Use gradio>=5.4.0 can also solve this issue.*

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
