### PR TITLE
fix: allow chunk_overlap with zero value

### DIFF
--- a/libs/ktem/ktem/index/file/pipelines.py
+++ b/libs/ktem/ktem/index/file/pipelines.py
@@ -742,7 +742,7 @@ class IndexDocumentPipeline(BaseFileIndexIndexing):
             loader=reader,
             splitter=TokenSplitter(
                 chunk_size=chunk_size or 1024,
-                chunk_overlap=chunk_overlap or 256,
+                chunk_overlap=chunk_overlap if chunk_overlap is not None else 256,
                 separator="\n\n",
                 backup_separators=["\n", ".", "\u200B"],
             ),


### PR DESCRIPTION
## Description

- Allows setting chunk_overlap of zero (as a way to disable overlap)
- Fixes #456

## Type of change

- [ ] New features (non-breaking change).
- [X] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [X ] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
