### PR TITLE
fix: update parameter name in AzureAIDocumentIntelligenceLoader

### DIFF
--- a/libs/kotaemon/kotaemon/loaders/azureai_document_intelligence_loader.py
+++ b/libs/kotaemon/kotaemon/loaders/azureai_document_intelligence_loader.py
@@ -133,7 +133,7 @@ class AzureAIDocumentIntelligenceLoader(BaseReader):
         with open(file_path, "rb") as fi:
             poller = self.client_.begin_analyze_document(
                 self.model,
-                analyze_request=fi,
+                body=fi,
                 content_type="application/octet-stream",
                 output_content_format=self.output_content_format,
             )


### PR DESCRIPTION
## Description

This is a fix for the error that occurs when using Azure Document Intelligence.

```
Using reader AzureAIDocumentIntelligenceLoader(cache_dir=/Users/hide/Git..., client_=<azure.ai.docum..., credential=, endpoint=, figure_friendly_filetypes=['.pdf', '.jpeg..., model=prebuilt-layout, output_content_format=markdown, vlm_endpoint=/openai/deploym...)
DocumentIntelligenceClientOperationsMixin.begin_analyze_document() missing 1 required positional argument: 'body'
Traceback (most recent call last):
  File "/Users/hide/Github/kotaemon/libs/ktem/ktem/index/file/pipelines.py", line 808, in stream
    file_id, docs = yield from pipeline.stream(
  File "/Users/hide/Github/kotaemon/libs/ktem/ktem/index/file/pipelines.py", line 646, in stream
    docs = self.loader.load_data(file_path, extra_info=extra_info)
  File "/Users/hide/Github/kotaemon/libs/kotaemon/kotaemon/loaders/azureai_document_intelligence_loader.py", line 134, in load_data
    poller = self.client_.begin_analyze_document(
  File "/Users/hide/Github/kotaemon/venv/lib/python3.10/site-packages/azure/core/tracing/decorator.py", line 105, in wrapper_use_tracer
    return func(*args, **kwargs)
TypeError: DocumentIntelligenceClientOperationsMixin.begin_analyze_document() missing 1 required positional argument: 'body'
```

The API of azure-ai-documentintelligence has changed in version 1.0.0.
- See: https://github.com/Azure/azure-sdk-for-python/commit/897f81deb3bbefc15db8608293863e0628d8d5a4

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
