### PR TITLE
feat: add options for Mistral AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT=text-embedding-ada-002
 # settings for Cohere
 COHERE_API_KEY=<COHERE_API_KEY>
 
+# settings for Mistral
+# MISTRAL_API_KEY=placeholder
+
 # settings for local models
 LOCAL_MODEL=qwen2.5:7b
 LOCAL_MODEL_EMBEDDINGS=nomic-embed-text

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -262,6 +262,14 @@ KH_EMBEDDINGS["google"] = {
     },
     "default": not IS_OPENAI_DEFAULT,
 }
+KH_EMBEDDINGS["mistral"] = {
+    "spec": {
+        "__type__": "kotaemon.embeddings.LCMistralEmbeddings",
+        "model": "mistral-embed",
+        "api_key": config("MISTRAL_API_KEY", default="your-key")
+    },
+    "default": True,
+}
 # KH_EMBEDDINGS["huggingface"] = {
 #     "spec": {
 #         "__type__": "kotaemon.embeddings.LCHuggingFaceEmbeddings",

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -275,7 +275,7 @@ KH_EMBEDDINGS["mistral"] = {
     "spec": {
         "__type__": "kotaemon.embeddings.LCMistralEmbeddings",
         "model": "mistral-embed",
-        "api_key": config("MISTRAL_API_KEY", default="your-key")
+        "api_key": config("MISTRAL_API_KEY", default="your-key"),
     },
     "default": False,
 }

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -277,7 +277,7 @@ KH_EMBEDDINGS["mistral"] = {
         "model": "mistral-embed",
         "api_key": config("MISTRAL_API_KEY", default="your-key")
     },
-    "default": True,
+    "default": False,
 }
 # KH_EMBEDDINGS["huggingface"] = {
 #     "spec": {

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -243,6 +243,15 @@ KH_LLMS["cohere"] = {
     },
     "default": False,
 }
+KH_LLMS["mistral"] = {
+    "spec": {
+        "__type__": "kotaemon.llms.ChatOpenAI",
+        "base_url": "https://api.mistral.ai/v1",
+        "model": "ministral-8b-latest",
+        "api_key": config("MISTRAL_API_KEY", default="your-key"),
+    },
+    "default": False,
+}
 
 # additional embeddings configurations
 KH_EMBEDDINGS["cohere"] = {

--- a/libs/kotaemon/kotaemon/embeddings/__init__.py
+++ b/libs/kotaemon/kotaemon/embeddings/__init__.py
@@ -5,6 +5,7 @@ from .langchain_based import (
     LCAzureOpenAIEmbeddings,
     LCCohereEmbeddings,
     LCGoogleEmbeddings,
+    LCMistralEmbeddings,
     LCHuggingFaceEmbeddings,
     LCOpenAIEmbeddings,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "LCCohereEmbeddings",
     "LCHuggingFaceEmbeddings",
     "LCGoogleEmbeddings",
+    "LCMistralEmbeddings",
     "OpenAIEmbeddings",
     "AzureOpenAIEmbeddings",
     "FastEmbedEmbeddings",

--- a/libs/kotaemon/kotaemon/embeddings/__init__.py
+++ b/libs/kotaemon/kotaemon/embeddings/__init__.py
@@ -5,8 +5,8 @@ from .langchain_based import (
     LCAzureOpenAIEmbeddings,
     LCCohereEmbeddings,
     LCGoogleEmbeddings,
-    LCMistralEmbeddings,
     LCHuggingFaceEmbeddings,
+    LCMistralEmbeddings,
     LCOpenAIEmbeddings,
 )
 from .openai import AzureOpenAIEmbeddings, OpenAIEmbeddings

--- a/libs/kotaemon/kotaemon/embeddings/langchain_based.py
+++ b/libs/kotaemon/kotaemon/embeddings/langchain_based.py
@@ -254,3 +254,39 @@ class LCGoogleEmbeddings(LCEmbeddingMixin, BaseEmbeddings):
             raise ImportError("Please install langchain-google-genai")
 
         return GoogleGenerativeAIEmbeddings
+
+
+class LCMistralEmbeddings(LCEmbeddingMixin, BaseEmbeddings):
+    """Wrapper around LangChain's MistralAI embedding, focusing on key parameters"""
+
+    api_key: str = Param(
+        help="API key (https://console.mistral.ai/api-keys)",
+        default=None,
+        required=True,
+    )
+    model: str = Param(
+        help="Model name to use ('mistral-embed')",
+        default="mistral-embed",
+        required=True,
+    )
+
+    def __init__(
+        self,
+        model: str = "mistral-embed",
+        api_key: Optional[str] = None,
+        **params,
+    ):
+        super().__init__(
+            model=model,
+            api_key=api_key,
+            **params,
+        )
+
+    def _get_lc_class(self):
+        try:
+            from langchain_mistralai import MistralAIEmbeddings
+        except ImportError:
+            raise ImportError(
+                "Please install langchain_mistralai: `pip install -U langchain_mistralai`"
+            )
+        return MistralAIEmbeddings

--- a/libs/kotaemon/kotaemon/embeddings/langchain_based.py
+++ b/libs/kotaemon/kotaemon/embeddings/langchain_based.py
@@ -287,6 +287,7 @@ class LCMistralEmbeddings(LCEmbeddingMixin, BaseEmbeddings):
             from langchain_mistralai import MistralAIEmbeddings
         except ImportError:
             raise ImportError(
-                "Please install langchain_mistralai: `pip install -U langchain_mistralai`"
+                "Please install langchain_mistralai: "
+                "`pip install -U langchain_mistralai`"
             )
         return MistralAIEmbeddings

--- a/libs/kotaemon/pyproject.toml
+++ b/libs/kotaemon/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "langchain-google-genai>=1.0.3,<2.0.0",
     "langchain-anthropic",
     "langchain-ollama",
+    "langchain-mistralai",
     "langchain-cohere>=0.2.4,<0.3.0",
     "llama-hub>=0.0.79,<0.1.0",
     "llama-index>=0.10.40,<0.11.0",

--- a/libs/ktem/ktem/embeddings/manager.py
+++ b/libs/ktem/ktem/embeddings/manager.py
@@ -58,8 +58,8 @@ class EmbeddingManager:
             FastEmbedEmbeddings,
             LCCohereEmbeddings,
             LCGoogleEmbeddings,
-            LCMistralEmbeddings,
             LCHuggingFaceEmbeddings,
+            LCMistralEmbeddings,
             OpenAIEmbeddings,
             TeiEndpointEmbeddings,
         )

--- a/libs/ktem/ktem/embeddings/manager.py
+++ b/libs/ktem/ktem/embeddings/manager.py
@@ -58,6 +58,7 @@ class EmbeddingManager:
             FastEmbedEmbeddings,
             LCCohereEmbeddings,
             LCGoogleEmbeddings,
+            LCMistralEmbeddings,
             LCHuggingFaceEmbeddings,
             OpenAIEmbeddings,
             TeiEndpointEmbeddings,
@@ -70,6 +71,7 @@ class EmbeddingManager:
             LCCohereEmbeddings,
             LCHuggingFaceEmbeddings,
             LCGoogleEmbeddings,
+            LCMistralEmbeddings,
             TeiEndpointEmbeddings,
         ]
 


### PR DESCRIPTION
## Description

- Added env variable, `flowsettings.py` options, embeddings, and dependencies to allow use of Mistral AI for Mistral AI LLM & embedding functionality
- `libs/ktem/ktem/pages/setup.py` changes not made, cannot select Mistral as a default option from intial setup page. I have some code in progress for this, but need to resolve a breaking change/bug

## Type of change

- [x] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
