### PR TITLE
fix: error 'history_messages' with LightRAG latest version

### DIFF
--- a/libs/ktem/ktem/index/file/graph/lightrag_pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/lightrag_pipelines.py
@@ -29,7 +29,10 @@ from .visualize import create_knowledge_graph, visualize_graph
 
 try:
     from lightrag import LightRAG, QueryParam
+    
+    # newer verisons of LightRAG needs to be initialized before using
     from lightrag.kg.shared_storage import initialize_pipeline_status
+
     from lightrag.operate import (
         _find_most_related_edges_from_entities,
         _find_most_related_text_unit_from_entities,
@@ -236,9 +239,11 @@ def build_graphrag(working_dir, llm_func, embedding_func):
         llm_model_func=llm_func,
         embedding_func=embedding_func,
     )
-    print("## DEBUG kotaemon ####################")
+
+    # newer verisons of LightRAG needs to be initialized before using
     asyncio.run(graphrag_func.initialize_storages())
     asyncio.run(initialize_pipeline_status())
+
     return graphrag_func
 
 

--- a/libs/ktem/ktem/index/file/graph/lightrag_pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/lightrag_pipelines.py
@@ -29,6 +29,7 @@ from .visualize import create_knowledge_graph, visualize_graph
 
 try:
     from lightrag import LightRAG, QueryParam
+    from lightrag.kg.shared_storage import initialize_pipeline_status
     from lightrag.operate import (
         _find_most_related_edges_from_entities,
         _find_most_related_text_unit_from_entities,
@@ -235,6 +236,9 @@ def build_graphrag(working_dir, llm_func, embedding_func):
         llm_model_func=llm_func,
         embedding_func=embedding_func,
     )
+    print("## DEBUG kotaemon ####################")
+    asyncio.run(graphrag_func.initialize_storages())
+    asyncio.run(initialize_pipeline_status())
     return graphrag_func
 
 


### PR DESCRIPTION
## Description
- Fixes: Error: 'history_messages' #702 

in libs/ktem/ktem/index/file/graph/lightrag_pipelines.py, line 236
```
def build_graphrag(working_dir, llm_func, embedding_func):
    graphrag_func = LightRAG(
        working_dir=working_dir,
        llm_model_func=llm_func,
        embedding_func=embedding_func,
    )

    # newer verisons of LightRAG needs to be initialized before using
    asyncio.run(graphrag_func.initialize_storages())
    asyncio.run(initialize_pipeline_status())

    return graphrag_func
```

I don't really know, which version of LightRag and which version of kotaemon are compatible and I did not find any hints regarding that. Please advice, if I missed something. 
I assume, the docker needs to be updated to use a new version of LightRag, too - I don't know how to...

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [ x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
