### PR TITLE
fix: update Docling call to generate figure caption

### DIFF
--- a/libs/kotaemon/kotaemon/loaders/docling_loader.py
+++ b/libs/kotaemon/kotaemon/loaders/docling_loader.py
@@ -124,7 +124,7 @@ class DoclingReader(BaseReader):
             else:
                 gen_caption_count += 1
                 gen_caption = generate_single_figure_caption(
-                    img_base64, self.vlm_endpoint
+                    figure=img_base64, vlm_endpoint=self.vlm_endpoint
                 )
 
             # join the extractive and generative captions


### PR DESCRIPTION
# Description

- PDF ingestion using Docling has been failing to generate captions for figures because the arguments into generate_single_figure_caption have been passed in the wrong order. As a result, the figure was being passed in as the vlm_endpoint, and the vlm_endpoint was being passed in as the figure. 
- Fixes #683 

## Type of change

- [ ] New features (non-breaking change).
- [X] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [X] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
