### PR TITLE
chore: added base_url parameter to CohereReranking

### DIFF
--- a/libs/kotaemon/kotaemon/rerankings/cohere.py
+++ b/libs/kotaemon/kotaemon/rerankings/cohere.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from decouple import config
 
 from kotaemon.base import Document, Param
@@ -23,6 +24,9 @@ class CohereReranking(BaseReranking):
         help="Cohere API key",
         required=True,
     )
+    base_url: str = Param(
+        None, help="Rerank API base url. Default is https://api.cohere.com", required=False
+    )
 
     def run(self, documents: list[Document], query: str) -> list[Document]:
         """Use Cohere Reranker model to re-order documents
@@ -38,7 +42,7 @@ class CohereReranking(BaseReranking):
             print("Cohere API key not found. Skipping rerankings.")
             return documents
 
-        cohere_client = cohere.Client(self.cohere_api_key)
+        cohere_client = cohere.Client(self.cohere_api_key, base_url=self.base_url or os.getenv("CO_API_URL"))
         compressed_docs: list[Document] = []
 
         if not documents:  # to avoid empty api call


### PR DESCRIPTION
## Description

Added base_url parameter to `CohereReranking` to enable Cohere-compatible rerank API, e.g. [vLLM rerank API](https://docs.vllm.ai/en/v0.7.1/serving/openai_compatible_server.html#re-rank-api) and [KServe rerank support](https://github.com/kserve/kserve/pull/4376).

## Type of change

- [X] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
