### PR TITLE
🐛 fix(docstore): preserve retrieval ranking order in lancedb get()

### DIFF
--- a/libs/kotaemon/kotaemon/storages/docstores/lancedb.py
+++ b/libs/kotaemon/kotaemon/storages/docstores/lancedb.py
@@ -113,14 +113,17 @@ class LanceDBDocumentStore(BaseDocumentStore):
             )
         except (ValueError, FileNotFoundError):
             docs = []
-        return [
-            Document(
-                id_=doc["id"],
+
+        # return the documents using the order of original ids (which were ordered by score)
+        doc_dict = {
+            doc["id"]: Document(
+                d_=doc["id"],
                 text=doc["text"] if doc["text"] else "<empty>",
                 metadata=json.loads(doc["attributes"]),
             )
             for doc in docs
-        ]
+        }
+        return [doc_dict[_id] for _id in ids if _id in doc_dict]
 
     def delete(self, ids: Union[List[str], str], refresh_indices: bool = True):
         """Delete document by id"""


### PR DESCRIPTION
## Description

This pull request fixes a bug in the `get()` method of the `lancedb` document store where documents retrieved by ID were returned in an arbitrary order (typically insertion order), rather than in the order of the input list of IDs.  

As a result, when using vector retrieval and pairing scores with documents (via `zip(docs, scores)`), the association between documents and their scores was incorrect. In fact, queries would return documents with low relevance scores that did not correspond to the top vector matches, often returning chunks from the first pages of documents due to insertion order, rather than the actual most relevant content.

Consider the following code:
```python
_, scores, ids = self.vector_store.query(
    embedding=emb, top_k=top_k_first_round, **kwargs
)
docs = self.doc_store.get(ids)
result = [
    RetrievedDocument(**doc.to_dict(), score=score)
    for doc, score in zip(docs, scores)
]
```

This PR modifies `get()` to return documents in the same order as ids, ensuring that the score-document mapping remains accurate.


## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] The feature is well documented.
