### PR TITLE
Add project-specific system prompt with fallback

### DIFF
--- a/libs/ktem/ktem/index/file/index.py
+++ b/libs/ktem/ktem/index/file/index.py
@@ -381,6 +381,16 @@ class FileIndex(BaseIndex):
         embedding_choices = list(embedding_models_manager.options().keys())
 
         return {
+            "project_system_prompt": {
+                "name": "Project System Prompt (Overrides Reasoning)",
+                "value": "",
+                "component": "text",
+                "info": (
+                    "Custom system prompt for this project. If set, this overrides "
+                    "the global system prompt defined in Reasoning Settings. "
+                    "Requires app restart after changing."
+                ),
+            },
             "embedding": {
                 "name": "Embedding model",
                 "value": embedding_default,

--- a/libs/ktem/ktem/reasoning/base.py
+++ b/libs/ktem/ktem/reasoning/base.py
@@ -38,6 +38,7 @@ class BaseReasoning(BaseComponent):
         user_settings: dict,
         state: dict,
         retrievers: Optional[list["BaseComponent"]] = None,
+        override_system_prompt: Optional[str] = None,
     ) -> "BaseReasoning":
         """Get the reasoning pipeline for the app to execute
 

--- a/libs/ktem/ktem/reasoning/simple.py
+++ b/libs/ktem/ktem/reasoning/simple.py
@@ -338,7 +338,7 @@ class FullQAPipeline(BaseReasoning):
         )
 
     @classmethod
-    def get_pipeline(cls, settings, states, retrievers):
+    def get_pipeline(cls, settings, states, retrievers, override_system_prompt=None):
         """Get the reasoning pipeline
 
         Args:
@@ -374,7 +374,11 @@ class FullQAPipeline(BaseReasoning):
         answer_pipeline.enable_mindmap = settings[f"{prefix}.create_mindmap"]
         answer_pipeline.enable_citation_viz = settings[f"{prefix}.create_citation_viz"]
         answer_pipeline.use_multimodal = settings[f"{prefix}.use_multimodal"]
-        answer_pipeline.system_prompt = settings[f"{prefix}.system_prompt"]
+        answer_pipeline.system_prompt = (
+            override_system_prompt
+            if override_system_prompt
+            else settings[f"{prefix}.system_prompt"]
+        )
         answer_pipeline.qa_template = settings[f"{prefix}.qa_prompt"]
         answer_pipeline.lang = SUPPORTED_LANGUAGE_MAP.get(
             settings["reasoning.lang"], "English"


### PR DESCRIPTION
This feature allows you to define a system prompt for each project (index).
- Added `project_system_prompt` to `FileIndex` admin settings.
- The `IndexManagement` UI will include this in the YAML config for projects.
- I modified the chat logic to use the project's system prompt if available, otherwise it falls back to the global system prompt in Reasoning Settings.
- Testing and documentation guidance have been outlined.

## Description

- Please include a summary of the changes and the related issue.
- Fixes # (issue)

## Type of change

- [ ] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
