### PR TITLE
added detailing to message of cautioning regarding the docker image u…

### DIFF
--- a/docs/local_model.md
+++ b/docs/local_model.md
@@ -4,7 +4,7 @@
 
 #### NOTE
 
-In the case of using Docker image, please replace `http://localhost` with `http://host.docker.internal` to correctly communicate with service on the host machine. See [more detail](https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container).
+In the case of using Docker image of kotaemon, please replace `http://localhost` with `http://host.docker.internal` wherever applicable to correctly communicate with service on the host machine. See [more detail](https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container).
 
 ### Ollama OpenAI compatible server (recommended)
 


### PR DESCRIPTION
…sage


current NOTE: 

In the case of using Docker image, please replace `http://localhost` with `http://host.docker.internal` to correctly communicate with service on the host machine.

Problem:

As this is the first line that the users reads, it might create the confusion regarding which docker image (whether it is the docker image of the model or the docker image of the kotaemon)

improved NOTE:

In the case of using Docker image of kotaemon, please replace `http://localhost` with `http://host.docker.internal` wherever applicable to correctly communicate with service on the host machine.

## Description

- Please include a summary of the changes and the related issue.
- Fixes # (issue)

## Type of change

- [ ] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
