### PR TITLE
fix: date_created default value always set to server start time

### DIFF
--- a/libs/ktem/ktem/index/file/index.py
+++ b/libs/ktem/ktem/index/file/index.py
@@ -78,7 +78,8 @@ class FileIndex(BaseIndex):
                     "path": Column(String),
                     "size": Column(Integer, default=0),
                     "date_created": Column(
-                        DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
+                        DateTime(timezone=True),
+                        default=lambda: datetime.now(get_localzone()),
                     ),
                     "user": Column(String, default=""),
                     "note": Column(
@@ -103,7 +104,8 @@ class FileIndex(BaseIndex):
                     "path": Column(String),
                     "size": Column(Integer, default=0),
                     "date_created": Column(
-                        DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
+                        DateTime(timezone=True),
+                        default=lambda: datetime.now(get_localzone()),
                     ),
                     "user": Column(String, default=""),
                     "note": Column(
@@ -139,7 +141,8 @@ class FileIndex(BaseIndex):
                     unique=True,
                 ),
                 "date_created": Column(
-                    DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
+                    DateTime(timezone=True),
+                    default=lambda: datetime.now(get_localzone()),
                 ),
                 "name": Column(String),
                 "user": Column(String, default=""),

--- a/libs/ktem/ktem/index/file/index.py
+++ b/libs/ktem/ktem/index/file/index.py
@@ -78,7 +78,7 @@ class FileIndex(BaseIndex):
                     "path": Column(String),
                     "size": Column(Integer, default=0),
                     "date_created": Column(
-                        DateTime(timezone=True), default=datetime.now(get_localzone())
+                        DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
                     ),
                     "user": Column(String, default=""),
                     "note": Column(
@@ -103,7 +103,7 @@ class FileIndex(BaseIndex):
                     "path": Column(String),
                     "size": Column(Integer, default=0),
                     "date_created": Column(
-                        DateTime(timezone=True), default=datetime.now(get_localzone())
+                        DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
                     ),
                     "user": Column(String, default=""),
                     "note": Column(
@@ -139,7 +139,7 @@ class FileIndex(BaseIndex):
                     unique=True,
                 ),
                 "date_created": Column(
-                    DateTime(timezone=True), default=datetime.now(get_localzone())
+                    DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
                 ),
                 "name": Column(String),
                 "user": Column(String, default=""),

--- a/scripts/migrate/migrate_chroma_db.py
+++ b/scripts/migrate/migrate_chroma_db.py
@@ -42,7 +42,8 @@ def _init_resource(private: bool = True, id: int = 1):
                 "path": Column(String),
                 "size": Column(Integer, default=0),
                 "date_created": Column(
-                    DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
+                    DateTime(timezone=True),
+                    default=lambda: datetime.now(get_localzone()),
                 ),
                 "user": Column(Integer, default=1),
                 "note": Column(
@@ -67,7 +68,8 @@ def _init_resource(private: bool = True, id: int = 1):
                 "path": Column(String),
                 "size": Column(Integer, default=0),
                 "date_created": Column(
-                    DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
+                    DateTime(timezone=True),
+                    default=lambda: datetime.now(get_localzone()),
                 ),
                 "user": Column(Integer, default=1),
                 "note": Column(

--- a/scripts/migrate/migrate_chroma_db.py
+++ b/scripts/migrate/migrate_chroma_db.py
@@ -42,7 +42,7 @@ def _init_resource(private: bool = True, id: int = 1):
                 "path": Column(String),
                 "size": Column(Integer, default=0),
                 "date_created": Column(
-                    DateTime(timezone=True), default=datetime.now(get_localzone())
+                    DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
                 ),
                 "user": Column(Integer, default=1),
                 "note": Column(
@@ -67,7 +67,7 @@ def _init_resource(private: bool = True, id: int = 1):
                 "path": Column(String),
                 "size": Column(Integer, default=0),
                 "date_created": Column(
-                    DateTime(timezone=True), default=datetime.now(get_localzone())
+                    DateTime(timezone=True), default=lambda: datetime.now(get_localzone())
                 ),
                 "user": Column(Integer, default=1),
                 "note": Column(


### PR DESCRIPTION
## Description

- `date_created` default value is always set to server start time

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
