### PR TITLE
fix: align next/previous link layout with Material for MkDocs theme

### DIFF
--- a/docs/theme/partials/footer.html
+++ b/docs/theme/partials/footer.html
@@ -16,10 +16,10 @@
             {% include ".icons/material/arrow-left.svg" %}
           </div>
           <div class="md-footer__title">
+            <span class="md-footer__direction">
+              {{ lang.t("footer.previous") }}
+            </span>
             <div class="md-ellipsis">
-              <span class="md-footer__direction">
-                {{ lang.t("footer.previous") }}
-              </span>
               {{ page.previous_page.title }}
             </div>
           </div>
@@ -32,10 +32,10 @@
           rel="next"
         >
           <div class="md-footer__title">
+            <span class="md-footer__direction">
+              {{ lang.t("footer.next") }}
+            </span>
             <div class="md-ellipsis">
-              <span class="md-footer__direction">
-                {{ lang.t("footer.next") }}
-              </span>
               {{ page.next_page.title }}
             </div>
           </div>


### PR DESCRIPTION
Fixes #799

## Description

This PR fixes the misalignment in the docs footer where the “Next” / “Previous” text and their page titles were appearing too close together (inline instead of stacked).
It aligns the layout with the official Material for MkDocs theme.

To fix this, I moved the `<span>` element with the direction label (Next / Previous) outside of the `.md-ellipsis` div, so the label and title now stack properly.

I verified this against Astral Docs and other sites using the same theme.

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
