### PR TITLE
fix(docs): align footer navigation labels with page titles

### DIFF
--- a/docs/extra/css/code_select.css
+++ b/docs/extra/css/code_select.css
@@ -3,3 +3,23 @@
   /* Generic.Prompt,  Generic.Output */
   user-select: none;
 }
+
+/* Fix footer navigation alignment (Issue #799)
+   Ensures proper spacing between direction labels and page titles */
+.md-footer__direction {
+  display: block;
+  font-size: 0.64rem;
+  margin-bottom: 0.2rem;
+  opacity: 0.7;
+}
+
+.md-footer__title {
+  flex-grow: 1;
+  max-width: calc(100% - 2.4rem);
+}
+
+.md-footer__link {
+  display: flex;
+  align-items: center;
+  padding-block: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- Adds CSS styles to properly align footer navigation direction labels with page titles
- Ensures consistent spacing matching Material for MkDocs default behavior

## Changes
- `docs/extra/css/code_select.css`: Added footer alignment styles

## Test Plan
- [x] Verified CSS syntax is valid
- [ ] Visual check on local docs build

Fixes #799

Signed-off-by: majiayu000 <1835304752@qq.com>