### PR TITLE
fix(file): delete physical cache files when removing documents

### DIFF
--- a/libs/ktem/ktem/index/file/ui.py
+++ b/libs/ktem/ktem/index/file/ui.py
@@ -444,6 +444,23 @@ class FileIndexPage(BasePage):
             gr.update(visible=file_id is not None),
         )
 
+    def _delete_matching_paths(self, cache_dir: Path, stem: str) -> None:
+        """Delete files matching the document stem in the given cache directory."""
+        if not cache_dir.exists():
+            return
+            
+        # Match exactly {stem}.* and {stem}_* to prevent overly broad deletion
+        patterns = [f"{stem}.*", f"{stem}_*"]
+        for pattern in patterns:
+            for file_path in cache_dir.glob(pattern):
+                try:
+                    if file_path.is_file():
+                        file_path.unlink()
+                    elif file_path.is_dir():
+                        shutil.rmtree(file_path)
+                except OSError as e:
+                    print(f"Warning: Failed to delete {file_path}: {e}")
+
     def _delete_physical_files(self, file_name: str) -> None:
         """Delete physical files associated with a document.
 
@@ -458,33 +475,13 @@ class FileIndexPage(BasePage):
 
         # Delete chunk cache files
         try:
-            chunks_dir = Path(flowsettings.KH_CHUNKS_OUTPUT_DIR)
-            if chunks_dir.exists():
-                for file_path in chunks_dir.iterdir():
-                    if file_stem in file_path.name:
-                        try:
-                            if file_path.is_file():
-                                file_path.unlink()
-                            elif file_path.is_dir():
-                                shutil.rmtree(file_path)
-                        except OSError as e:
-                            print(f"Warning: Failed to delete {file_path}: {e}")
+            self._delete_matching_paths(Path(flowsettings.KH_CHUNKS_OUTPUT_DIR), file_stem)
         except Exception as e:
             print(f"Warning: Error cleaning chunks cache: {e}")
 
         # Delete markdown cache files
         try:
-            markdown_dir = Path(flowsettings.KH_MARKDOWN_OUTPUT_DIR)
-            if markdown_dir.exists():
-                for file_path in markdown_dir.iterdir():
-                    if file_stem in file_path.name:
-                        try:
-                            if file_path.is_file():
-                                file_path.unlink()
-                            elif file_path.is_dir():
-                                shutil.rmtree(file_path)
-                        except OSError as e:
-                            print(f"Warning: Failed to delete {file_path}: {e}")
+            self._delete_matching_paths(Path(flowsettings.KH_MARKDOWN_OUTPUT_DIR), file_stem)
         except Exception as e:
             print(f"Warning: Error cleaning markdown cache: {e}")
 

--- a/libs/ktem/ktem_tests/test_file_deletion.py
+++ b/libs/ktem/ktem_tests/test_file_deletion.py
@@ -1,0 +1,120 @@
+"""Tests for file deletion functionality."""
+
+import shutil
+from pathlib import Path
+
+
+class TestDeletePhysicalFiles:
+    """Test the _delete_physical_files method."""
+
+    def test_delete_chunk_cache_files(self, tmp_path):
+        """Test that chunk cache files are deleted."""
+        # Setup: Create test directory and files
+        chunks_dir = tmp_path / "chunks_cache_dir"
+        chunks_dir.mkdir()
+
+        # Create test files matching the file stem
+        test_file_stem = "test_document"
+        (chunks_dir / f"{test_file_stem}.chunks.json").write_text("chunks data")
+        (chunks_dir / f"{test_file_stem}_part1.txt").write_text("part 1")
+        (chunks_dir / "other_file.txt").write_text("other")  # Should not be deleted
+
+        # Verify files exist
+        assert (chunks_dir / f"{test_file_stem}.chunks.json").exists()
+        assert (chunks_dir / f"{test_file_stem}_part1.txt").exists()
+        assert (chunks_dir / "other_file.txt").exists()
+
+        # Simulate deletion
+        file_stem = Path("test_document.pdf").stem
+        for file_path in chunks_dir.iterdir():
+            if file_stem in file_path.name:
+                file_path.unlink()
+
+        # Verify target files are deleted but other files remain
+        assert not (chunks_dir / f"{test_file_stem}.chunks.json").exists()
+        assert not (chunks_dir / f"{test_file_stem}_part1.txt").exists()
+        assert (chunks_dir / "other_file.txt").exists()
+
+    def test_delete_markdown_cache_files(self, tmp_path):
+        """Test that markdown cache files are deleted."""
+        # Setup: Create test directory and files
+        markdown_dir = tmp_path / "markdown_cache_dir"
+        markdown_dir.mkdir()
+
+        # Create test files matching the file stem
+        test_file_stem = "test_document"
+        (markdown_dir / f"{test_file_stem}.md").write_text("markdown content")
+        (markdown_dir / "unrelated.md").write_text("other")  # Should not be deleted
+
+        # Verify files exist
+        assert (markdown_dir / f"{test_file_stem}.md").exists()
+        assert (markdown_dir / "unrelated.md").exists()
+
+        # Simulate deletion
+        file_stem = Path("test_document.pdf").stem
+        for file_path in markdown_dir.iterdir():
+            if file_stem in file_path.name:
+                file_path.unlink()
+
+        # Verify target files are deleted but other files remain
+        assert not (markdown_dir / f"{test_file_stem}.md").exists()
+        assert (markdown_dir / "unrelated.md").exists()
+
+    def test_delete_directory_cache(self, tmp_path):
+        """Test that cache directories are deleted."""
+        # Setup: Create test directory with subdirectory
+        chunks_dir = tmp_path / "chunks_cache_dir"
+        chunks_dir.mkdir()
+
+        test_file_stem = "test_document"
+        sub_dir = chunks_dir / f"{test_file_stem}_cache"
+        sub_dir.mkdir()
+        (sub_dir / "cached_data.txt").write_text("cached")
+
+        # Verify directory exists
+        assert sub_dir.exists()
+
+        # Simulate deletion
+        file_stem = Path("test_document.pdf").stem
+        for file_path in chunks_dir.iterdir():
+            if file_stem in file_path.name:
+                if file_path.is_dir():
+                    shutil.rmtree(file_path)
+
+        # Verify directory is deleted
+        assert not sub_dir.exists()
+
+    def test_empty_file_name_does_nothing(self, tmp_path):
+        """Test that empty file name causes no deletion."""
+        chunks_dir = tmp_path / "chunks_cache_dir"
+        chunks_dir.mkdir()
+        (chunks_dir / "test.txt").write_text("content")
+
+        # With empty file name, nothing should happen
+        file_stem = Path("").stem
+        deleted_count = 0
+        for file_path in chunks_dir.iterdir():
+            if file_stem and file_stem in file_path.name:
+                deleted_count += 1
+
+        assert deleted_count == 0
+        assert (chunks_dir / "test.txt").exists()
+
+    def test_nonexistent_cache_dirs_handled(self, tmp_path):
+        """Test that missing cache directories don't cause errors."""
+        # Non-existent directory
+        chunks_dir = tmp_path / "nonexistent_chunks_dir"
+        markdown_dir = tmp_path / "nonexistent_markdown_dir"
+
+        # Should not raise any errors
+        assert not chunks_dir.exists()
+        assert not markdown_dir.exists()
+
+        # Simulating the check in _delete_physical_files
+        if chunks_dir.exists():
+            pass  # Would iterate but doesn't exist
+        if markdown_dir.exists():
+            pass  # Would iterate but doesn't exist
+
+        # No errors should be raised
+        assert True

--- a/libs/ktem/ktem_tests/test_file_deletion.py
+++ b/libs/ktem/ktem_tests/test_file_deletion.py
@@ -2,6 +2,9 @@
 
 import shutil
 from pathlib import Path
+from unittest.mock import patch
+
+from ktem.index.file.ui import FileIndexPage
 
 
 class TestDeletePhysicalFiles:
@@ -9,112 +12,109 @@ class TestDeletePhysicalFiles:
 
     def test_delete_chunk_cache_files(self, tmp_path):
         """Test that chunk cache files are deleted."""
-        # Setup: Create test directory and files
         chunks_dir = tmp_path / "chunks_cache_dir"
         chunks_dir.mkdir()
+        markdown_dir = tmp_path / "markdown_cache_dir"
+        markdown_dir.mkdir()
 
-        # Create test files matching the file stem
         test_file_stem = "test_document"
         (chunks_dir / f"{test_file_stem}.chunks.json").write_text("chunks data")
         (chunks_dir / f"{test_file_stem}_part1.txt").write_text("part 1")
-        (chunks_dir / "other_file.txt").write_text("other")  # Should not be deleted
+        (chunks_dir / "other_file.txt").write_text("other")
 
-        # Verify files exist
         assert (chunks_dir / f"{test_file_stem}.chunks.json").exists()
         assert (chunks_dir / f"{test_file_stem}_part1.txt").exists()
         assert (chunks_dir / "other_file.txt").exists()
 
-        # Simulate deletion
-        file_stem = Path("test_document.pdf").stem
-        for file_path in chunks_dir.iterdir():
-            if file_stem in file_path.name:
-                file_path.unlink()
+        page = FileIndexPage.__new__(FileIndexPage)
+        
+        with patch("ktem.index.file.ui.flowsettings") as mock_settings:
+            mock_settings.KH_CHUNKS_OUTPUT_DIR = str(chunks_dir)
+            mock_settings.KH_MARKDOWN_OUTPUT_DIR = str(markdown_dir)
+            page._delete_physical_files("test_document.pdf")
 
-        # Verify target files are deleted but other files remain
         assert not (chunks_dir / f"{test_file_stem}.chunks.json").exists()
         assert not (chunks_dir / f"{test_file_stem}_part1.txt").exists()
         assert (chunks_dir / "other_file.txt").exists()
 
     def test_delete_markdown_cache_files(self, tmp_path):
         """Test that markdown cache files are deleted."""
-        # Setup: Create test directory and files
+        chunks_dir = tmp_path / "chunks_cache_dir"
+        chunks_dir.mkdir()
         markdown_dir = tmp_path / "markdown_cache_dir"
         markdown_dir.mkdir()
 
-        # Create test files matching the file stem
         test_file_stem = "test_document"
         (markdown_dir / f"{test_file_stem}.md").write_text("markdown content")
-        (markdown_dir / "unrelated.md").write_text("other")  # Should not be deleted
+        (markdown_dir / "unrelated.md").write_text("other")
 
-        # Verify files exist
         assert (markdown_dir / f"{test_file_stem}.md").exists()
         assert (markdown_dir / "unrelated.md").exists()
 
-        # Simulate deletion
-        file_stem = Path("test_document.pdf").stem
-        for file_path in markdown_dir.iterdir():
-            if file_stem in file_path.name:
-                file_path.unlink()
+        page = FileIndexPage.__new__(FileIndexPage)
 
-        # Verify target files are deleted but other files remain
+        with patch("ktem.index.file.ui.flowsettings") as mock_settings:
+            mock_settings.KH_CHUNKS_OUTPUT_DIR = str(chunks_dir)
+            mock_settings.KH_MARKDOWN_OUTPUT_DIR = str(markdown_dir)
+            page._delete_physical_files("test_document.pdf")
+
         assert not (markdown_dir / f"{test_file_stem}.md").exists()
         assert (markdown_dir / "unrelated.md").exists()
 
     def test_delete_directory_cache(self, tmp_path):
         """Test that cache directories are deleted."""
-        # Setup: Create test directory with subdirectory
         chunks_dir = tmp_path / "chunks_cache_dir"
         chunks_dir.mkdir()
+        markdown_dir = tmp_path / "markdown_cache_dir"
+        markdown_dir.mkdir()
 
         test_file_stem = "test_document"
         sub_dir = chunks_dir / f"{test_file_stem}_cache"
         sub_dir.mkdir()
         (sub_dir / "cached_data.txt").write_text("cached")
 
-        # Verify directory exists
         assert sub_dir.exists()
 
-        # Simulate deletion
-        file_stem = Path("test_document.pdf").stem
-        for file_path in chunks_dir.iterdir():
-            if file_stem in file_path.name:
-                if file_path.is_dir():
-                    shutil.rmtree(file_path)
+        page = FileIndexPage.__new__(FileIndexPage)
 
-        # Verify directory is deleted
+        with patch("ktem.index.file.ui.flowsettings") as mock_settings:
+            mock_settings.KH_CHUNKS_OUTPUT_DIR = str(chunks_dir)
+            mock_settings.KH_MARKDOWN_OUTPUT_DIR = str(markdown_dir)
+            page._delete_physical_files("test_document.pdf")
+
         assert not sub_dir.exists()
 
     def test_empty_file_name_does_nothing(self, tmp_path):
         """Test that empty file name causes no deletion."""
         chunks_dir = tmp_path / "chunks_cache_dir"
         chunks_dir.mkdir()
+        markdown_dir = tmp_path / "markdown_cache_dir"
+        markdown_dir.mkdir()
         (chunks_dir / "test.txt").write_text("content")
 
-        # With empty file name, nothing should happen
-        file_stem = Path("").stem
-        deleted_count = 0
-        for file_path in chunks_dir.iterdir():
-            if file_stem and file_stem in file_path.name:
-                deleted_count += 1
+        page = FileIndexPage.__new__(FileIndexPage)
 
-        assert deleted_count == 0
+        with patch("ktem.index.file.ui.flowsettings") as mock_settings:
+            mock_settings.KH_CHUNKS_OUTPUT_DIR = str(chunks_dir)
+            mock_settings.KH_MARKDOWN_OUTPUT_DIR = str(markdown_dir)
+            page._delete_physical_files("")
+
         assert (chunks_dir / "test.txt").exists()
 
     def test_nonexistent_cache_dirs_handled(self, tmp_path):
         """Test that missing cache directories don't cause errors."""
-        # Non-existent directory
         chunks_dir = tmp_path / "nonexistent_chunks_dir"
         markdown_dir = tmp_path / "nonexistent_markdown_dir"
 
-        # Should not raise any errors
-        assert not chunks_dir.exists()
-        assert not markdown_dir.exists()
+        page = FileIndexPage.__new__(FileIndexPage)
 
-        # Simulating the check in _delete_physical_files
-        if chunks_dir.exists():
-            pass  # Would iterate but doesn't exist
-        if markdown_dir.exists():
-            pass  # Would iterate but doesn't exist
+        with patch("ktem.index.file.ui.flowsettings") as mock_settings:
+            mock_settings.KH_CHUNKS_OUTPUT_DIR = str(chunks_dir)
+            mock_settings.KH_MARKDOWN_OUTPUT_DIR = str(markdown_dir)
+            # Should not raise any errors
+            page._delete_physical_files("test_document.pdf")
 
-        # No errors should be raised
-        assert True
+        # No operation should create any new files or directories
+        # If an error were raised, the test would fail; here we assert that
+        # the temporary directory remains empty.
+        assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- Add `_delete_physical_files` method to clean up cache files on document deletion
- Delete chunk cache files from `KH_CHUNKS_OUTPUT_DIR`
- Delete markdown cache files from `KH_MARKDOWN_OUTPUT_DIR`
- Graceful error handling to prevent deletion failures from blocking the operation

## Test plan
- [x] Added unit tests for cache file deletion scenarios
- [x] Tests cover: file deletion, directory deletion, empty filename, missing dirs

Fixes #717