### PR TITLE
fix: Change default model of CohereReranking

### DIFF
--- a/libs/kotaemon/kotaemon/rerankings/cohere.py
+++ b/libs/kotaemon/kotaemon/rerankings/cohere.py
@@ -13,7 +13,7 @@ class CohereReranking(BaseReranking):
     """Cohere Reranking model"""
 
     model_name: str = Param(
-        "rerank-multilingual-v2.0",
+        "rerank-multilingual-v3.0",
         help=(
             "ID of the model to use. You can go to [Supported Models]"
             "(https://docs.cohere.com/docs/rerank-2) to see the supported models"


### PR DESCRIPTION
## Description
Hello :) Thank you for your maintenance.
The previous default model for Cohere, rerank-multilingual-v2.0, has been deprecated, so I’ve updated the default to rerank-multilingual-v3.0.

## Type of change

- [x] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
