### PR TITLE
feat: add MiniMax as a supported LLM provider with M3 as default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ COHERE_API_KEY=<COHERE_API_KEY>
 # settings for Mistral
 # MISTRAL_API_KEY=placeholder
 
+# settings for MiniMax
+# MINIMAX_API_KEY=<YOUR_MINIMAX_API_KEY>
+
 # settings for VoyageAI
 VOYAGE_API_KEY=<VOYAGE_API_KEY>
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ documents and developers who want to build their own RAG pipeline.
 ### For end users
 
 - **Clean & Minimalistic UI**: A user-friendly interface for RAG-based QA.
-- **Support for Various LLMs**: Compatible with LLM API providers (OpenAI, AzureOpenAI, Cohere, etc.) and local LLMs (via `ollama` and `llama-cpp-python`).
+- **Support for Various LLMs**: Compatible with LLM API providers (OpenAI, AzureOpenAI, Cohere, MiniMax, etc.) and local LLMs (via `ollama` and `llama-cpp-python`).
 - **Easy Installation**: Simple scripts to get you started quickly.
 
 ### For developers
@@ -68,7 +68,7 @@ documents and developers who want to build their own RAG pipeline.
 
 - **Host your own document QA (RAG) web-UI**: Support multi-user login, organize your files in private/public collections, collaborate and share your favorite chat with others.
 
-- **Organize your LLM & Embedding models**: Support both local LLMs & popular API providers (OpenAI, Azure, Ollama, Groq).
+- **Organize your LLM & Embedding models**: Support both local LLMs & popular API providers (OpenAI, Azure, Ollama, Groq, MiniMax).
 
 - **Hybrid RAG pipeline**: Sane default RAG pipeline with hybrid (full-text & vector) retriever and re-ranking to ensure best retrieval quality.
 
@@ -339,6 +339,18 @@ This file provides another way to configure your models and credentials.
     AZURE_OPENAI_CHAT_DEPLOYMENT=gpt-35-turbo
     AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT=text-embedding-ada-002
     ```
+
+  - **MiniMax**
+
+    [MiniMax](https://www.minimaxi.com) offers large language models with a 204,800-token
+    context window via an OpenAI-compatible API. Set `MINIMAX_API_KEY` in your `.env` file
+    to enable MiniMax models.
+
+    ```shell
+    MINIMAX_API_KEY=<your MiniMax API key here>
+    ```
+
+    Available models: `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
 
   - **Local Models**
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ This file provides another way to configure your models and credentials.
     MINIMAX_API_KEY=<your MiniMax API key here>
     ```
 
-    Available models: `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
+    Available models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
 
   - **Local Models**
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ This file provides another way to configure your models and credentials.
     MINIMAX_API_KEY=<your MiniMax API key here>
     ```
 
-    Available models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
+    Available models: `MiniMax-M3` (default), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`.
 
   - **Local Models**
 

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -275,7 +275,7 @@ KH_LLMS["minimax"] = {
     "spec": {
         "__type__": "kotaemon.llms.ChatMiniMax",
         "base_url": "https://api.minimax.io/v1",
-        "model": "MiniMax-M2.5",
+        "model": "MiniMax-M2.7",
         "api_key": config("MINIMAX_API_KEY", default="your-key"),
         "temperature": 1.0,
     },

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -271,6 +271,16 @@ KH_LLMS["mistral"] = {
     },
     "default": False,
 }
+KH_LLMS["minimax"] = {
+    "spec": {
+        "__type__": "kotaemon.llms.ChatMiniMax",
+        "base_url": "https://api.minimax.io/v1",
+        "model": "MiniMax-M2.5",
+        "api_key": config("MINIMAX_API_KEY", default="your-key"),
+        "temperature": 1.0,
+    },
+    "default": False,
+}
 
 # additional embeddings configurations
 KH_EMBEDDINGS["cohere"] = {

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -275,7 +275,7 @@ KH_LLMS["minimax"] = {
     "spec": {
         "__type__": "kotaemon.llms.ChatMiniMax",
         "base_url": "https://api.minimax.io/v1",
-        "model": "MiniMax-M2.7",
+        "model": "MiniMax-M3",
         "api_key": config("MINIMAX_API_KEY", default="your-key"),
         "temperature": 1.0,
     },

--- a/libs/kotaemon/kotaemon/llms/__init__.py
+++ b/libs/kotaemon/kotaemon/llms/__init__.py
@@ -5,6 +5,7 @@ from .branching import GatedBranchingPipeline, SimpleBranchingPipeline
 from .chats import (
     AzureChatOpenAI,
     ChatLLM,
+    ChatMiniMax,
     ChatOpenAI,
     EndpointChatLLM,
     LCAnthropicChat,
@@ -31,6 +32,7 @@ __all__ = [
     "AIMessage",
     "SystemMessage",
     "AzureChatOpenAI",
+    "ChatMiniMax",
     "ChatOpenAI",
     "StructuredOutputChatOpenAI",
     "LCAnthropicChat",

--- a/libs/kotaemon/kotaemon/llms/chats/__init__.py
+++ b/libs/kotaemon/kotaemon/llms/chats/__init__.py
@@ -10,11 +10,13 @@ from .langchain_based import (
     LCOllamaChat,
 )
 from .llamacpp import LlamaCppChat
+from .minimax import ChatMiniMax
 from .openai import AzureChatOpenAI, ChatOpenAI, StructuredOutputChatOpenAI
 
 __all__ = [
     "ChatOpenAI",
     "AzureChatOpenAI",
+    "ChatMiniMax",
     "ChatLLM",
     "EndpointChatLLM",
     "ChatOpenAI",

--- a/libs/kotaemon/kotaemon/llms/chats/minimax.py
+++ b/libs/kotaemon/kotaemon/llms/chats/minimax.py
@@ -1,0 +1,57 @@
+from typing import Optional
+
+from kotaemon.base import Param
+
+from .openai import ChatOpenAI
+
+
+class ChatMiniMax(ChatOpenAI):
+    """MiniMax chat model, using the OpenAI-compatible API
+
+    MiniMax provides large language models accessible via an OpenAI-compatible
+    endpoint. Supported models: MiniMax-M2.5, MiniMax-M2.5-highspeed.
+
+    Both models support a 204,800-token context window.
+
+    Note:
+        - Temperature must be in (0.0, 1.0]; zero is not accepted.
+        - The ``response_format`` parameter is not supported and will be
+          removed from requests automatically.
+
+    Attributes:
+        base_url: API base URL. Defaults to the global endpoint
+            ``https://api.minimax.io/v1``. The China endpoint
+            ``https://api.minimaxi.com/v1`` is also available.
+        model: Model ID to use. Defaults to ``MiniMax-M2.5``.
+        api_key: MiniMax API key (``MINIMAX_API_KEY``).
+    """
+
+    base_url: Optional[str] = Param(
+        "https://api.minimax.io/v1",
+        help=(
+            "MiniMax API base URL. Use https://api.minimax.io/v1 (global) "
+            "or https://api.minimaxi.com/v1 (China)."
+        ),
+    )
+    model: str = Param(
+        "MiniMax-M2.5",
+        help="MiniMax model ID (MiniMax-M2.5 or MiniMax-M2.5-highspeed)",
+        required=True,
+    )
+    temperature: Optional[float] = Param(
+        1.0,
+        help=(
+            "Sampling temperature. Must be in (0.0, 1.0]. "
+            "MiniMax does not accept 0."
+        ),
+    )
+
+    def prepare_params(self, **kwargs):
+        params = super().prepare_params(**kwargs)
+        # MiniMax does not support response_format
+        params.pop("response_format", None)
+        # Clamp temperature: MiniMax rejects 0
+        if "temperature" in params and params["temperature"] is not None:
+            if params["temperature"] <= 0:
+                params["temperature"] = 0.01
+        return params

--- a/libs/kotaemon/kotaemon/llms/chats/minimax.py
+++ b/libs/kotaemon/kotaemon/llms/chats/minimax.py
@@ -9,7 +9,8 @@ class ChatMiniMax(ChatOpenAI):
     """MiniMax chat model, using the OpenAI-compatible API
 
     MiniMax provides large language models accessible via an OpenAI-compatible
-    endpoint. Supported models: MiniMax-M2.5, MiniMax-M2.5-highspeed.
+    endpoint. Supported models: MiniMax-M2.7, MiniMax-M2.7-highspeed,
+    MiniMax-M2.5, MiniMax-M2.5-highspeed.
 
     Both models support a 204,800-token context window.
 
@@ -22,7 +23,7 @@ class ChatMiniMax(ChatOpenAI):
         base_url: API base URL. Defaults to the global endpoint
             ``https://api.minimax.io/v1``. The China endpoint
             ``https://api.minimaxi.com/v1`` is also available.
-        model: Model ID to use. Defaults to ``MiniMax-M2.5``.
+        model: Model ID to use. Defaults to ``MiniMax-M2.7``.
         api_key: MiniMax API key (``MINIMAX_API_KEY``).
     """
 
@@ -34,8 +35,8 @@ class ChatMiniMax(ChatOpenAI):
         ),
     )
     model: str = Param(
-        "MiniMax-M2.5",
-        help="MiniMax model ID (MiniMax-M2.5 or MiniMax-M2.5-highspeed)",
+        "MiniMax-M2.7",
+        help="MiniMax model ID (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, or MiniMax-M2.5-highspeed)",
         required=True,
     )
     temperature: Optional[float] = Param(

--- a/libs/kotaemon/kotaemon/llms/chats/minimax.py
+++ b/libs/kotaemon/kotaemon/llms/chats/minimax.py
@@ -9,10 +9,11 @@ class ChatMiniMax(ChatOpenAI):
     """MiniMax chat model, using the OpenAI-compatible API
 
     MiniMax provides large language models accessible via an OpenAI-compatible
-    endpoint. Supported models: MiniMax-M2.7, MiniMax-M2.7-highspeed,
-    MiniMax-M2.5, MiniMax-M2.5-highspeed.
+    endpoint. Supported models: MiniMax-M3, MiniMax-M2.7,
+    MiniMax-M2.7-highspeed.
 
-    Both models support a 204,800-token context window.
+    MiniMax-M3 supports a 512K-token context window with up to 128K output and
+    image input. The M2.7 series supports a 204,800-token context window.
 
     Note:
         - Temperature must be in (0.0, 1.0]; zero is not accepted.
@@ -23,7 +24,7 @@ class ChatMiniMax(ChatOpenAI):
         base_url: API base URL. Defaults to the global endpoint
             ``https://api.minimax.io/v1``. The China endpoint
             ``https://api.minimaxi.com/v1`` is also available.
-        model: Model ID to use. Defaults to ``MiniMax-M2.7``.
+        model: Model ID to use. Defaults to ``MiniMax-M3``.
         api_key: MiniMax API key (``MINIMAX_API_KEY``).
     """
 
@@ -35,8 +36,8 @@ class ChatMiniMax(ChatOpenAI):
         ),
     )
     model: str = Param(
-        "MiniMax-M2.7",
-        help="MiniMax model ID (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, or MiniMax-M2.5-highspeed)",
+        "MiniMax-M3",
+        help="MiniMax model ID (MiniMax-M3, MiniMax-M2.7, or MiniMax-M2.7-highspeed)",
         required=True,
     )
     temperature: Optional[float] = Param(

--- a/libs/kotaemon/tests/test_llms_chat_models.py
+++ b/libs/kotaemon/tests/test_llms_chat_models.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from kotaemon.base.schema import AIMessage, HumanMessage, LLMInterface, SystemMessage
-from kotaemon.llms import AzureChatOpenAI, LlamaCppChat
+from kotaemon.llms import AzureChatOpenAI, ChatMiniMax, LlamaCppChat
 
 try:
     pass
@@ -71,6 +71,33 @@ def test_azureopenai_model(openai_completion):
         output, LLMInterface
     ), "Output for single text is not LLMInterface"
     openai_completion.assert_called()
+
+
+@patch(
+    "openai.resources.chat.completions.Completions.create",
+    side_effect=lambda *args, **kwargs: _openai_chat_completion_response,
+)
+def test_minimax_model(openai_completion):
+    model = ChatMiniMax(
+        api_key="dummy",
+        model="MiniMax-M2.5",
+    )
+    output = model("hello world")
+    assert isinstance(output, LLMInterface), "Output is not LLMInterface"
+    openai_completion.assert_called()
+
+    # verify temperature clamping: zero should become 0.01
+    model_zero_temp = ChatMiniMax(
+        api_key="dummy",
+        model="MiniMax-M2.5",
+        temperature=0,
+    )
+    params = model_zero_temp.prepare_params()
+    assert params["temperature"] == 0.01, "Temperature 0 should be clamped to 0.01"
+
+    # verify response_format is stripped
+    params_with_rf = model.prepare_params(response_format={"type": "json_object"})
+    assert "response_format" not in params_with_rf, "response_format should be removed"
 
 
 @skip_llama_cpp_not_installed

--- a/libs/kotaemon/tests/test_llms_chat_models.py
+++ b/libs/kotaemon/tests/test_llms_chat_models.py
@@ -80,7 +80,7 @@ def test_azureopenai_model(openai_completion):
 def test_minimax_model(openai_completion):
     model = ChatMiniMax(
         api_key="dummy",
-        model="MiniMax-M2.5",
+        model="MiniMax-M2.7",
     )
     output = model("hello world")
     assert isinstance(output, LLMInterface), "Output is not LLMInterface"
@@ -89,7 +89,7 @@ def test_minimax_model(openai_completion):
     # verify temperature clamping: zero should become 0.01
     model_zero_temp = ChatMiniMax(
         api_key="dummy",
-        model="MiniMax-M2.5",
+        model="MiniMax-M2.7",
         temperature=0,
     )
     params = model_zero_temp.prepare_params()
@@ -98,6 +98,28 @@ def test_minimax_model(openai_completion):
     # verify response_format is stripped
     params_with_rf = model.prepare_params(response_format={"type": "json_object"})
     assert "response_format" not in params_with_rf, "response_format should be removed"
+
+
+@patch(
+    "openai.resources.chat.completions.Completions.create",
+    side_effect=lambda *args, **kwargs: _openai_chat_completion_response,
+)
+def test_minimax_default_model_is_m27(openai_completion):
+    """Default model should be MiniMax-M2.7."""
+    model = ChatMiniMax(api_key="dummy")
+    assert model.model == "MiniMax-M2.7", "Default model should be MiniMax-M2.7"
+
+    # M2.7-highspeed should also work
+    model_hs = ChatMiniMax(api_key="dummy", model="MiniMax-M2.7-highspeed")
+    output = model_hs("hello world")
+    assert isinstance(output, LLMInterface), "Output is not LLMInterface"
+    openai_completion.assert_called()
+
+    # Older M2.5 models should still work
+    model_old = ChatMiniMax(api_key="dummy", model="MiniMax-M2.5")
+    output = model_old("hello world")
+    assert isinstance(output, LLMInterface), "Output is not LLMInterface"
+    openai_completion.assert_called()
 
 
 @skip_llama_cpp_not_installed

--- a/libs/kotaemon/tests/test_llms_chat_models.py
+++ b/libs/kotaemon/tests/test_llms_chat_models.py
@@ -80,7 +80,7 @@ def test_azureopenai_model(openai_completion):
 def test_minimax_model(openai_completion):
     model = ChatMiniMax(
         api_key="dummy",
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
     )
     output = model("hello world")
     assert isinstance(output, LLMInterface), "Output is not LLMInterface"
@@ -89,7 +89,7 @@ def test_minimax_model(openai_completion):
     # verify temperature clamping: zero should become 0.01
     model_zero_temp = ChatMiniMax(
         api_key="dummy",
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         temperature=0,
     )
     params = model_zero_temp.prepare_params()
@@ -104,20 +104,20 @@ def test_minimax_model(openai_completion):
     "openai.resources.chat.completions.Completions.create",
     side_effect=lambda *args, **kwargs: _openai_chat_completion_response,
 )
-def test_minimax_default_model_is_m27(openai_completion):
-    """Default model should be MiniMax-M2.7."""
+def test_minimax_default_model_is_m3(openai_completion):
+    """Default model should be MiniMax-M3."""
     model = ChatMiniMax(api_key="dummy")
-    assert model.model == "MiniMax-M2.7", "Default model should be MiniMax-M2.7"
+    assert model.model == "MiniMax-M3", "Default model should be MiniMax-M3"
+
+    # M2.7 should still work
+    model_m27 = ChatMiniMax(api_key="dummy", model="MiniMax-M2.7")
+    output = model_m27("hello world")
+    assert isinstance(output, LLMInterface), "Output is not LLMInterface"
+    openai_completion.assert_called()
 
     # M2.7-highspeed should also work
     model_hs = ChatMiniMax(api_key="dummy", model="MiniMax-M2.7-highspeed")
     output = model_hs("hello world")
-    assert isinstance(output, LLMInterface), "Output is not LLMInterface"
-    openai_completion.assert_called()
-
-    # Older M2.5 models should still work
-    model_old = ChatMiniMax(api_key="dummy", model="MiniMax-M2.5")
-    output = model_old("hello world")
     assert isinstance(output, LLMInterface), "Output is not LLMInterface"
     openai_completion.assert_called()
 

--- a/libs/ktem/ktem/llms/manager.py
+++ b/libs/ktem/ktem/llms/manager.py
@@ -56,6 +56,7 @@ class LLMManager:
     def load_vendors(self):
         from kotaemon.llms import (
             AzureChatOpenAI,
+            ChatMiniMax,
             ChatOpenAI,
             LCAnthropicChat,
             LCCohereChat,
@@ -67,6 +68,7 @@ class LLMManager:
         self._vendors = [
             ChatOpenAI,
             AzureChatOpenAI,
+            ChatMiniMax,
             LCAnthropicChat,
             LCGeminiChat,
             LCCohereChat,


### PR DESCRIPTION
## Summary
- Add MiniMax as a supported LLM provider via OpenAI-compatible API
- Default model is now **MiniMax-M3** (512K context, up to 128K output, image input)
- Keep MiniMax-M2.7 and MiniMax-M2.7-highspeed as alternatives
- Temperature clamping and response_format removal for MiniMax API compatibility
- Register ChatMiniMax in vendor list for UI model selection

## Changes
- `libs/kotaemon/kotaemon/llms/chats/minimax.py` — ChatMiniMax class extending ChatOpenAI; default `MiniMax-M3`
- `libs/ktem/ktem/llms/manager.py` — Register ChatMiniMax as vendor
- `flowsettings.py` — Default MiniMax config uses `MiniMax-M3`
- `.env.example` — `MINIMAX_API_KEY` placeholder
- `README.md` — MiniMax documentation listing M3 (default), M2.7, M2.7-highspeed
- `libs/kotaemon/tests/test_llms_chat_models.py` — Unit tests verifying M3 as default and M2.7 backward compatibility

## Why
MiniMax-M3 is the latest flagship model, providing a 512K context window, up to 128K output, and image input via the OpenAI-compatible endpoint. Keeping M2.7 and M2.7-highspeed preserves access to the previous generation.

## Testing
- Unit tests updated and passing
- Default model verified as `MiniMax-M3`
- Backward compatibility verified for `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`
- Temperature clamping and `response_format` removal still verified