### PR TITLE
fix: handle KeyError in VectorRetrieval when thumbnail doc IDs mismatch

### DIFF
--- a/libs/kotaemon/kotaemon/indices/vectorindex.py
+++ b/libs/kotaemon/kotaemon/indices/vectorindex.py
@@ -281,9 +281,15 @@ class VectorRetrieval(BaseRetrieval):
             len(raw_thumbnail_docs),
         )
         additional_docs = []
+        matched_thumbnail_ids: set[str] = set()
 
         for thumbnail_doc in linked_thumbnail_docs:
-            text_doc = text_thumbnail_docs[thumbnail_doc.doc_id]
+            text_doc = text_thumbnail_docs.get(thumbnail_doc.doc_id)
+            if text_doc is None:
+                # Skip thumbnails whose doc_id doesn't match any
+                # text chunk's thumbnail_doc_id (e.g. due to stale index data)
+                continue
+            matched_thumbnail_ids.add(thumbnail_doc.doc_id)
             doc_dict = thumbnail_doc.to_dict()
             doc_dict["_id"] = text_doc.doc_id
             doc_dict["content"] = text_doc.content
@@ -293,6 +299,11 @@ class VectorRetrieval(BaseRetrieval):
                     doc_dict["metadata"][key] = text_doc.metadata[key]
 
             additional_docs.append(RetrievedDocument(**doc_dict, score=text_doc.score))
+
+        # Add back text chunks whose thumbnails could not be matched
+        for tid, text_doc in text_thumbnail_docs.items():
+            if tid not in matched_thumbnail_ids:
+                non_thumbnail_docs.append(text_doc)
 
         result = additional_docs + non_thumbnail_docs
 


### PR DESCRIPTION
## Summary

- Fixes a `KeyError` crash in `VectorRetrieval.run()` when thumbnail documents retrieved from the docstore have `doc_id` values that don't match the `thumbnail_doc_id` references stored in text chunk metadata.
- Uses `dict.get()` with a `None` check instead of direct dictionary access (`text_thumbnail_docs[thumbnail_doc.doc_id]`) to gracefully skip unmatched thumbnails.
- Adds back any text chunks whose thumbnails could not be matched so they still appear in the query results instead of being silently dropped.

Fixes #759

## Root Cause

In `libs/kotaemon/kotaemon/indices/vectorindex.py`, the retrieval pipeline collects `thumbnail_doc_id` references from text chunk metadata and fetches the corresponding thumbnail documents from the docstore. However, the docstore can return documents whose `doc_id` attributes don't match the requested IDs (e.g., due to stale index data or ID mismatches after reindexing). The direct dictionary lookup `text_thumbnail_docs[thumbnail_doc.doc_id]` then raises a `KeyError`, crashing the entire retrieval pipeline.

## Test plan

- [ ] Upload a PDF document and query it with thumbnail retrieval enabled - verify no KeyError occurs
- [ ] Verify that text chunks are still returned in results even when their referenced thumbnail documents cannot be matched
- [ ] Confirm that matched thumbnails continue to work correctly and appear alongside their text chunks