### PR TITLE
fix: update default Cohere rerank model to rerank-v4.0-fast

### DIFF
--- a/flowsettings.py
+++ b/flowsettings.py
@@ -310,7 +310,7 @@ KH_EMBEDDINGS["mistral"] = {
 KH_RERANKINGS["cohere"] = {
     "spec": {
         "__type__": "kotaemon.rerankings.CohereReranking",
-        "model_name": "rerank-multilingual-v2.0",
+        "model_name": "rerank-v4.0-fast",
         "cohere_api_key": config("COHERE_API_KEY", default=""),
     },
     "default": True,

--- a/libs/kotaemon/kotaemon/indices/rankings/cohere.py
+++ b/libs/kotaemon/kotaemon/indices/rankings/cohere.py
@@ -8,7 +8,7 @@ from .base import BaseReranking
 
 
 class CohereReranking(BaseReranking):
-    model_name: str = "rerank-multilingual-v2.0"
+    model_name: str = "rerank-v4.0-fast"
     cohere_api_key: str = config("COHERE_API_KEY", "")
     use_key_from_ktem: bool = False
 

--- a/libs/kotaemon/kotaemon/rerankings/cohere.py
+++ b/libs/kotaemon/kotaemon/rerankings/cohere.py
@@ -13,10 +13,11 @@ class CohereReranking(BaseReranking):
     """Cohere Reranking model"""
 
     model_name: str = Param(
-        "rerank-multilingual-v2.0",
+        "rerank-v4.0-fast",
         help=(
-            "ID of the model to use. You can go to [Supported Models]"
-            "(https://docs.cohere.com/docs/rerank-2) to see the supported models"
+            "ID of the model to use. See [Cohere Rerank models]"
+            "(https://docs.cohere.com/docs/models#rerank) for supported IDs "
+            "(e.g. rerank-v4.0-fast, rerank-v4.0-pro, rerank-multilingual-v3.0)."
         ),
         required=True,
     )

--- a/libs/ktem/ktem/pages/setup.py
+++ b/libs/ktem/ktem/pages/setup.py
@@ -226,7 +226,7 @@ class SetupPage(BasePage):
                     name="cohere",
                     spec={
                         "__type__": "kotaemon.rerankings.CohereReranking",
-                        "model_name": "rerank-multilingual-v2.0",
+                        "model_name": "rerank-v4.0-fast",
                         "cohere_api_key": cohere_api_key,
                     },
                     default=True,


### PR DESCRIPTION
## Summary

As discussed in #822, this PR updates the default Cohere rerank model from the retired `rerank-multilingual-v2.0` to `rerank-v4.0-fast` as suggested by @cin-niko.

## Changes

- **libs/kotaemon/kotaemon/rerankings/cohere.py**: Updated default model to `rerank-v4.0-fast`, added sunset model alias mapping (v2.0/v3.0 → v4.0-fast) with user notification
- **libs/kotaemon/kotaemon/indices/rankings/cohere.py**: Updated default model and integrated alias resolution
- **flowsettings.py**: Updated KH_RERANKINGS default config
- **libs/ktem/ktem/pages/setup.py**: Updated first-time setup default

## Backward Compatibility

Legacy stored configs referencing sunset models will automatically remap to `rerank-v4.0-fast` at runtime with a console warning, preventing 404 failures without requiring manual UI intervention.

## Evidence that the code works

<img width="1667" height="903" alt="image" src="https://github.com/user-attachments/assets/8c6d2d02-96f8-479c-860b-836fcd28c9d3" />

<img width="1236" height="613" alt="image" src="https://github.com/user-attachments/assets/637a47bf-4452-4ac3-8d2d-087115d082ec" />


## Closes

Closes #823
