### PR TITLE
fix: add type=table filter to prioritize table retrieval

### DIFF
--- a/libs/ktem/ktem/index/file/pipelines.py
+++ b/libs/ktem/ktem/index/file/pipelines.py
@@ -192,7 +192,13 @@ class DocumentRetrievalPipeline(BaseFileIndexRetriever):
             table_pages[doc.metadata["file_name"]].append(doc.metadata["page_label"])
 
         queries: list[dict] = [
-            {"$and": [{"file_name": {"$eq": fn}}, {"page_label": {"$in": pls}}]}
+            {
+                "$and": [
+                    {"file_name": {"$eq": fn}},
+                    {"page_label": {"$in": pls}},
+                    {"type": {"$eq": "table"}},
+                ]
+            }
             for fn, pls in table_pages.items()
         ]
         if queries:


### PR DESCRIPTION
Fixes #752

## Problem

When the "Prioritize Table" option is enabled, `DocumentRetrievalPipeline` retrieves extra documents from pages that contain relevant content. However, the metadata filter only matched by `file_name` and `page_label`, which caused it to fetch **all document chunks** on those pages — including non-table documents like regular text paragraphs.

As a result, the table documents that should be prioritized were not being reliably retrieved: the secondary retrieval was pulling in all document types, not just tables.

## Solution

Added `{"type": {"$eq": "table"}}` to the metadata filter in the extra-table retrieval query. This ensures only documents with `type="table"` are fetched in the secondary retrieval pass, aligning with the intent of the "Prioritize Table" feature.

## Testing

- Verified the metadata filter structure matches how tables are stored (e.g., `doc.metadata.get("type", "") == "table"` used in `reasoning/react.py`, `reasoning/rewoo.py`, and `qa/format_context.py`)
- The fix is a minimal, targeted change with no side effects on the main retrieval path