### PR TITLE
docs: update uv installation instructions to remove missing run_uv.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,24 +144,29 @@ documents and developers who want to build their own RAG pipeline.
 
 #### Option 1: Using uv (Recommended for faster installation)
 
-1. Clone the repository and run the uv installation script:
+1. Clone the repository and install dependencies:
 
    ```shell
    # clone this repo
    git clone https://github.com/Cinnamon/kotaemon
    cd kotaemon
 
-   # run the uv installation script (installs uv automatically if not present)
-   bash scripts/run_uv.sh
+   # install uv if not already installed (https://docs.astral.sh/uv/getting-started/installation/)
+   # then install all dependencies
+   uv sync
    ```
 
-   This script will:
+2. (Optional) Set up PDF.js viewer:
 
-   - Install uv package manager if not present
-   - Create a virtual environment with Python 3.10
-   - Install all dependencies using uv (significantly faster than conda/pip)
-   - Set up PDF.js viewer
-   - Launch the application
+   ```shell
+   bash scripts/download_pdfjs.sh pdfjs-4.0.379-dist
+   ```
+
+3. Start the application:
+
+   ```shell
+   uv run python app.py
+   ```
 
 #### Option 2: Using conda (Traditional method)
 


### PR DESCRIPTION
Fixes #821

## Problem

The README's "Option 1: Using uv" section referenced `bash scripts/run_uv.sh`, a script that was removed in a previous version. Users following the README received `No such file or directory` immediately.

## Solution

Replaced the broken script reference with explicit uv commands that reflect the actual installation workflow:
1. `uv sync` — installs all dependencies using the existing `uv.lock`
2. `bash scripts/download_pdfjs.sh pdfjs-4.0.379-dist` — optional PDF.js viewer setup
3. `uv run python app.py` — launches the application

This matches the approach used in CI/Dockerfile and is consistent with the `pyproject.toml` uv workspace configuration.

## Testing

Verified the commands match the project's actual uv workspace setup (`pyproject.toml`, `uv.lock`).