### PR TITLE
fix: handle missing GraphRAG index gracefully instead of crashing

### DIFF
--- a/libs/ktem/ktem/index/file/graph/lightrag_pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/lightrag_pipelines.py
@@ -444,7 +444,10 @@ class LightRAGRetrieverPipeline(BaseFileIndexRetriever):
                 .first()
             )
             graph_id = graph_id[0] if graph_id else None
-            assert graph_id, f"GraphRAG index not found for file_id: {file_id}"
+
+        if not graph_id:
+            logging.warning(f"GraphRAG index not found for file_id: {file_id}")
+            return None, None
 
         _, input_path = prepare_graph_index_path(graph_id)
         input_path.mkdir(parents=True, exist_ok=True)
@@ -511,6 +514,8 @@ class LightRAGRetrieverPipeline(BaseFileIndexRetriever):
             return []
 
         graphrag_func, query_params = self._build_graph_search()
+        if graphrag_func is None:
+            return []
 
         # only local mode support graph visualization
         if query_params.mode == "local":

--- a/libs/ktem/ktem/index/file/graph/nano_pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/nano_pipelines.py
@@ -432,7 +432,10 @@ class NanoGraphRAGRetrieverPipeline(BaseFileIndexRetriever):
                 .first()
             )
             graph_id = graph_id[0] if graph_id else None
-            assert graph_id, f"GraphRAG index not found for file_id: {file_id}"
+
+        if not graph_id:
+            logging.warning(f"GraphRAG index not found for file_id: {file_id}")
+            return None, None
 
         _, input_path = prepare_graph_index_path(graph_id)
         input_path.mkdir(parents=True, exist_ok=True)
@@ -507,6 +510,8 @@ class NanoGraphRAGRetrieverPipeline(BaseFileIndexRetriever):
             return []
 
         graphrag_func, query_params = self._build_graph_search()
+        if graphrag_func is None:
+            return []
 
         # only local mode support graph visualization
         if query_params.mode == "local":

--- a/libs/ktem/ktem/index/file/graph/pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/pipelines.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import logging
 from pathlib import Path
 from shutil import rmtree
 from typing import Generator
@@ -201,7 +202,10 @@ class GraphRAGRetrieverPipeline(BaseFileIndexRetriever):
                 .first()
             )
             graph_id = graph_id[0] if graph_id else None
-            assert graph_id, f"GraphRAG index not found for file_id: {file_id}"
+
+        if not graph_id:
+            logging.warning(f"GraphRAG index not found for file_id: {file_id}")
+            return None
 
         root_path, _ = prepare_graph_index_path(graph_id)
         output_path = root_path / "output"
@@ -362,6 +366,8 @@ class GraphRAGRetrieverPipeline(BaseFileIndexRetriever):
             raise ValueError(GRAPHRAG_KEY_MISSING_MESSAGE)
 
         context_builder = self._build_graph_search()
+        if context_builder is None:
+            return []
 
         local_context_params = {
             "text_unit_prop": 0.5,


### PR DESCRIPTION
Fixes #711

## Problem

When a file is uploaded to a GraphRAG/LightRAG/NanoGraphRAG index panel and selected in the chat file selector, the app crashes with an `AssertionError` if the file's graph index is not found in the database:

```
AssertionError: GraphRAG index not found for file_id: <uuid>
```

This happens when, for example:
- A CSV file is uploaded to the LightRAG panel but indexing failed silently
- A file is selected before its graph index has been fully built
- The index database is out of sync with the actual indexed files

## Solution

Replace the `assert` statement with a graceful check in `_build_graph_search()` across all three graph retriever pipelines:
- `lightrag_pipelines.py` (LightRAGRetrieverPipeline)
- `nano_pipelines.py` (NanoGraphRAGRetrieverPipeline)
- `pipelines.py` (GraphRAGRetrieverPipeline)

When the graph index is not found, the method now logs a warning and returns early (empty result) instead of raising an `AssertionError`. This allows the other retrievers (vector store, etc.) to continue working normally.

## Testing

- Upload a file to LightRAG index
- Before/after full indexing completes, select the file in chat
- The app no longer crashes; other retrievers continue to function