### PR TITLE
fix: gracefully handle pipeline init errors due to corrupted SQLite cache

### DIFF
--- a/libs/ktem/ktem/pages/chat/__init__.py
+++ b/libs/ktem/ktem/pages/chat/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import re
 from copy import deepcopy
 from typing import Optional
@@ -1368,7 +1369,15 @@ class ChatPage(BasePage):
             )
 
     def check_and_suggest_name_conv(self, chat_history):
-        suggest_pipeline = SuggestConvNamePipeline()
+        try:
+            suggest_pipeline = SuggestConvNamePipeline()
+        except Exception as e:
+            logging.warning(
+                f"Failed to initialize SuggestConvNamePipeline: {e}. "
+                "Skipping conversation name suggestion."
+            )
+            return gr.update(), False
+
         new_name = gr.update()
         renamed = False
 
@@ -1395,7 +1404,15 @@ class ChatPage(BasePage):
             else settings["reasoning.lang"]
         )
         if use_suggestion:
-            suggest_pipeline = SuggestFollowupQuesPipeline()
+            try:
+                suggest_pipeline = SuggestFollowupQuesPipeline()
+            except Exception as e:
+                logging.warning(
+                    f"Failed to initialize SuggestFollowupQuesPipeline: {e}. "
+                    "Skipping follow-up question suggestion."
+                )
+                return gr.update(visible=False), gr.update()
+
             suggest_pipeline.lang = SUPPORTED_LANGUAGE_MAP.get(
                 target_language, "English"
             )


### PR DESCRIPTION
Fixes #744

## Problem

After running kotaemon for an extended period (e.g., in a tmux session), the `diskcache`/SQLite cache used by `theflow` can become unavailable or corrupted. This causes `sqlite3.OperationalError: no such table: Cache` to propagate unhandled when `SuggestConvNamePipeline` or `SuggestFollowupQuesPipeline` are initialized, crashing the chat callback and surfacing as an error to the user on every action.

## Solution

Wrap the pipeline initialization calls in `check_and_suggest_name_conv` and `suggest_chat_conv` with `try/except` blocks. When initialization fails, a warning is logged and the functions return a graceful no-op result instead of propagating the error. The naming and follow-up suggestion features are non-critical — the chat still works correctly without them.

## Testing

- Verified that the guard returns `gr.update(), False` from `check_and_suggest_name_conv` without crashing when pipeline init raises an exception.
- The happy path (no exception) is unchanged.