### PR TITLE
ci: pin free-disk-space to a full commit SHA

### DIFF
--- a/.github/workflows/build-push-docker.yaml
+++ b/.github/workflows/build-push-docker.yaml
@@ -33,7 +33,7 @@ jobs:
       max-parallel: 1
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB


### PR DESCRIPTION
## What
Pin `jlumbroso/free-disk-space` in `build-push-docker.yaml` from `@main` to the v1.3.1 release commit.

## Why
It's the first step of the `build` job, which holds `packages: write` + `id-token: write`, logs into ghcr.io with `GITHUB_TOKEN`, and pushes the published container images. `@main` is a moving branch, so the exact third-party code running alongside those credentials can change without any change here. Pinning to a full SHA closes that; behaviour unchanged.

I used AI assistance to identify this and draft the change; I verified it against the live workflows myself.