### PR TITLE
fix: multiple bug fixes across rerankings, indexing, config and app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,15 @@
 import os
+from pathlib import Path
 
 from theflow.settings import settings as flowsettings
 
+_APP_DIR = Path(__file__).parent
+
 KH_APP_DATA_DIR = getattr(flowsettings, "KH_APP_DATA_DIR", ".")
 KH_GRADIO_SHARE = getattr(flowsettings, "KH_GRADIO_SHARE", False)
-GRADIO_TEMP_DIR = os.getenv("GRADIO_TEMP_DIR", None)
-# override GRADIO_TEMP_DIR if it's not set
-if GRADIO_TEMP_DIR is None:
+GRADIO_TEMP_DIR = os.getenv("GRADIO_TEMP_DIR")
+# override GRADIO_TEMP_DIR if it's not set or is empty
+if not GRADIO_TEMP_DIR:
     GRADIO_TEMP_DIR = os.path.join(KH_APP_DATA_DIR, "gradio_tmp")
     os.environ["GRADIO_TEMP_DIR"] = GRADIO_TEMP_DIR
 
@@ -17,9 +20,9 @@ app = App()
 demo = app.make()
 demo.queue().launch(
     favicon_path=app._favicon,
-    inbrowser=True,
+    inbrowser=os.getenv("KH_OPEN_BROWSER", "0") == "1",
     allowed_paths=[
-        "libs/ktem/ktem/assets",
+        str(_APP_DIR / "libs/ktem/ktem/assets"),
         GRADIO_TEMP_DIR,
     ],
     share=KH_GRADIO_SHARE,

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -353,10 +353,11 @@ SETTINGS_REASONING = {
     },
 }
 
-USE_GLOBAL_GRAPHRAG = config("USE_GLOBAL_GRAPHRAG", default=True, cast=bool)
-USE_NANO_GRAPHRAG = config("USE_NANO_GRAPHRAG", default=False, cast=bool)
-USE_LIGHTRAG = config("USE_LIGHTRAG", default=True, cast=bool)
-USE_MS_GRAPHRAG = config("USE_MS_GRAPHRAG", default=True, cast=bool)
+_to_bool = lambda v: str(v).strip().lower() in ("true", "1", "yes") if v else False
+USE_GLOBAL_GRAPHRAG = config("USE_GLOBAL_GRAPHRAG", default=True, cast=_to_bool)
+USE_NANO_GRAPHRAG = config("USE_NANO_GRAPHRAG", default=False, cast=_to_bool)
+USE_LIGHTRAG = config("USE_LIGHTRAG", default=True, cast=_to_bool)
+USE_MS_GRAPHRAG = config("USE_MS_GRAPHRAG", default=True, cast=_to_bool)
 
 GRAPHRAG_INDEX_TYPES = []
 

--- a/libs/ktem/ktem/index/file/ui.py
+++ b/libs/ktem/ktem/index/file/ui.py
@@ -1272,7 +1272,7 @@ class FileIndexPage(BasePage):
         n_successes = len([_ for _ in results if _])
         if n_successes:
             gr.Info(f"Successfully index {n_successes} files")
-        n_errors = len([_ for _ in errors if _])
+        n_errors = len([_ for _ in index_errors if _])
         if n_errors:
             gr.Warning(f"Have errors for {n_errors} files")
 

--- a/libs/ktem/ktem/rerankings/ui.py
+++ b/libs/ktem/ktem/rerankings/ui.py
@@ -149,7 +149,7 @@ class RerankingManagement(BasePage):
             if value.get("required", False):
                 required[key] = value.get("default", None)
 
-            return yaml.dump(required), format_description(vendor)
+        return yaml.dump(required), format_description(vendor)
 
     def on_register_events(self):
         self.rerank_choices.select(


### PR DESCRIPTION
Fixes 6 bugs found during code review:

1. **Return-inside-for-loop in `rerankings/ui.py`** — The `return` was
   inside the `for` loop, so only the first vendor parameter was ever
   processed (copy-paste error from `embeddings/ui.py`).

2. **Undefined variable in `index/file/ui.py`** — `errors` was never
   defined; should be `index_errors` (from `StopIteration.value`).
   Crashed whenever the indexing generator finished.

3. **`bool` casting bug in `flowsettings.py`** — `python-decouple`'s
   `cast=bool` treated any non-empty string (including `"False"`,
   `"0"`, `"no"`) as `True` for GraphRAG flags.

4. **Empty-string `GRADIO_TEMP_DIR` in `app.py`** — `os.getenv(..., None)`
   only returned `None` when unset, not when set to `""`. Downstream
   received an empty path.

5. **Hardcoded relative asset path in `app.py`** — `"libs/ktem/ktem/assets"`
   broke if CWD != project root. Now resolved via `Path(__file__)`.

6. **`inbrowser=True` on headless servers** — Made configurable via
   `KH_OPEN_BROWSER` env var, defaulting to off.