### PR TITLE
fix: sanitize PaddleOCR table HTML

### DIFF
--- a/libs/kotaemon/kotaemon/loaders/paddleocr_loader/adapter.py
+++ b/libs/kotaemon/kotaemon/loaders/paddleocr_loader/adapter.py
@@ -1,14 +1,47 @@
 """PaddleOCR result adapter for converting raw output to Documents."""
 
 import base64
-import re
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+from bs4 import BeautifulSoup, Comment, Doctype
+
 from kotaemon.base import Document
 from kotaemon.loaders.azureai_document_intelligence_loader import crop_image
+
+ALLOWED_TABLE_TAGS: set[str] = {
+    "br",
+    "caption",
+    "col",
+    "colgroup",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+}
+
+ALLOWED_TABLE_ATTRIBUTES: dict[str, set[str]] = {
+    "col": {"span"},
+    "td": {"colspan", "rowspan"},
+    "th": {"colspan", "rowspan", "scope"},
+}
+
+DROP_CONTENT_TAGS: set[str] = {
+    "embed",
+    "iframe",
+    "math",
+    "noscript",
+    "object",
+    "script",
+    "style",
+    "svg",
+    "template",
+}
 
 TEXT_LABELS: set[str] = {
     "text",
@@ -214,11 +247,27 @@ class PaddleOCRResult:
         return text_docs, tables, figures
 
     def _clean_table_html(self, html_content: str) -> str:
-        """Clean HTML table content for better readability."""
-        html_content = re.sub(
-            r"<html><body>(.*?)</body></html>",
-            r"\1",
-            html_content,
-            flags=re.DOTALL,
-        )
-        return html_content.strip()
+        """Keep safe table structure while removing unsafe HTML."""
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        for tag in soup.find_all(tuple(DROP_CONTENT_TAGS)):
+            tag.decompose()
+
+        for tag in soup.find_all(True):
+            if tag.name not in ALLOWED_TABLE_TAGS:
+                tag.unwrap()
+                continue
+
+            allowed_attributes = ALLOWED_TABLE_ATTRIBUTES.get(tag.name, set())
+            tag.attrs = {
+                name: value
+                for name, value in tag.attrs.items()
+                if name in allowed_attributes
+            }
+
+        for node in soup.find_all(string=lambda value: isinstance(value, Comment)):
+            node.extract()
+        for node in soup.find_all(string=lambda value: isinstance(value, Doctype)):
+            node.extract()
+
+        return soup.decode_contents().strip()

--- a/libs/kotaemon/tests/test_paddleocr_loader.py
+++ b/libs/kotaemon/tests/test_paddleocr_loader.py
@@ -37,6 +37,29 @@ def test_clean_table_html_strips_wrapper() -> None:
     assert out.strip() == "<table>x</table>"
 
 
+def test_clean_table_html_sanitizes_unsafe_content() -> None:
+    """_clean_table_html preserves table structure without unsafe HTML."""
+    raw = [_make_page_result({"page_index": 0, "parsing_res_list": []})]
+    result = PaddleOCRResult(
+        raw_result=raw, file_path=Path("/tmp/doc.pdf"), extra_info={}
+    )
+
+    out = result._clean_table_html(
+        '<table onclick="alert(1)"><tr><td colspan="2" onmouseover="alert(1)">'
+        '<script>alert("script")</script><img src="x" onerror="alert(1)">'
+        'Safe <a href="javascript:alert(1)">link</a></td></tr></table>'
+    )
+
+    assert '<td colspan="2">' in out
+    assert "Safe link" in out
+    assert "script" not in out
+    assert "img" not in out
+    assert "onclick" not in out
+    assert "onmouseover" not in out
+    assert "onerror" not in out
+    assert "javascript:" not in out
+
+
 def test_file_name_property() -> None:
     """file_name returns the path name."""
     raw = [_make_page_result({"page_index": 0, "parsing_res_list": []})]
@@ -84,6 +107,41 @@ def test_to_documents_text_and_table() -> None:
     assert "A" in table_docs[0].text
     assert table_docs[0].metadata["table_origin"]
     assert table_docs[0].metadata["page_label"] == 1
+
+
+def test_to_documents_sanitizes_table_html_before_storage() -> None:
+    """Table text and table_origin contain the same sanitized HTML."""
+    raw = [
+        _make_page_result(
+            {
+                "page_index": 0,
+                "parsing_res_list": [
+                    {
+                        "block_label": "table",
+                        "block_content": (
+                            '<table><tr><th rowspan="2" style="color:red">A</th>'
+                            '<td><iframe src="https://example.com"></iframe>'
+                            '<span onmouseenter="alert(1)">B</span></td></tr></table>'
+                        ),
+                    },
+                ],
+            }
+        )
+    ]
+    result = PaddleOCRResult(
+        raw_result=raw,
+        file_path=Path("doc.pdf"),
+        extra_info={},
+    )
+
+    table_doc = result.to_documents()[0]
+
+    assert table_doc.text == table_doc.metadata["table_origin"]
+    assert '<th rowspan="2">A</th>' in table_doc.text
+    assert "<td>B</td>" in table_doc.text
+    assert "style" not in table_doc.text
+    assert "iframe" not in table_doc.text
+    assert "onmouseenter" not in table_doc.text
 
 
 def test_to_documents_skips_empty_content() -> None:


### PR DESCRIPTION
## Description

- sanitize PaddleOCR table HTML before it is stored in `Document.text` and
  `table_origin`
- preserve table structure and safe layout attributes such as `rowspan` and
  `colspan`
- remove executable elements, event-handler attributes, unsafe URLs, and other
  non-table markup while preserving readable text
- add regression coverage for direct sanitization and the document storage path

Fixes #834

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Validation

- `pytest libs/kotaemon/tests/test_paddleocr_loader.py -q`
  - 6 passed, 12 skipped because the optional PaddleOCR dependency is not installed
- `pre-commit run --files libs/kotaemon/kotaemon/loaders/paddleocr_loader/adapter.py libs/kotaemon/tests/test_paddleocr_loader.py`
  - all hooks passed
- `pytest libs/kotaemon/tests -q`
  - 113 passed, 20 skipped
  - 5 unrelated Milvus Lite tests failed because its local mmap manager did not initialize

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
