### PR TITLE
fix(indexing): treat special tokens as text

### DIFF
--- a/libs/ktem/ktem/index/file/pipelines.py
+++ b/libs/ktem/ktem/index/file/pipelines.py
@@ -76,7 +76,11 @@ def dev_settings():
     return file_extractors, chunk_size, chunk_overlap
 
 
-_default_token_func = tiktoken.encoding_for_model("gpt-3.5-turbo").encode
+_default_tokenizer = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+
+def _default_token_func(text: str) -> list[int]:
+    return _default_tokenizer.encode(text, disallowed_special=())
 
 
 class DocumentRetrievalPipeline(BaseFileIndexRetriever):

--- a/libs/ktem/ktem_tests/test_file_pipeline.py
+++ b/libs/ktem/ktem_tests/test_file_pipeline.py
@@ -1,0 +1,10 @@
+import tiktoken
+
+from ktem.index.file.pipelines import _default_token_func
+
+
+def test_default_token_func_treats_special_tokens_as_text():
+    text = "before <|endoftext|> after"
+    encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+    assert _default_token_func(text) == encoding.encode(text, disallowed_special=())


### PR DESCRIPTION
## Description

- Treat tiktoken special-token markers found in indexed documents as ordinary source text when calculating token counts.
- Keep the tokenizer cached while making the intended `disallowed_special=()` behavior explicit and covered by a regression test.
- Fixes #311.

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas. (The small tokenizer wrapper is self-explanatory; no additional comment is needed.)
- [x] The feature is well documented. (No user-facing documentation changes are needed for this bug fix.)

## Regression evidence

- Before the fix, the focused regression test raised `ValueError` for literal `<|endoftext|>` input.
- After the fix, the same test passes and matches `encoding.encode(text, disallowed_special=())`.

## Verification

- `pytest libs/ktem/ktem_tests/test_file_pipeline.py -q`: 1 passed.
- `pytest libs/kotaemon/tests/`: 116 passed, 20 skipped.
- `pre-commit run --all-files`: all hooks passed.
- `git diff --check`: passed.
