### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,11 +394,11 @@ Please cite this project as
 
 ## Star History
 
-<a href="https://star-history.com/#Cinnamon/kotaemon&Date">
+<a href="https://star-history.dera.page/#Cinnamon/kotaemon&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Cinnamon/kotaemon&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Cinnamon/kotaemon&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Cinnamon/kotaemon&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Cinnamon/kotaemon&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Cinnamon/kotaemon&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Cinnamon/kotaemon&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the GitHub stargazer API it relied on is restricted. This change points the chart to star-history.dera.page, which uses an alternative data source that needs no API token, so the chart works again.