### PR TITLE
fix: file-index error count, reranker toast label, script and doc typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ This file provides another way to configure your models and credentials.
 #### Custom Reasoning Pipeline
 
 1. Check the default pipeline implementation in [here](libs/ktem/ktem/reasoning/simple.py). You can make quick adjustment to how the default QA pipeline work.
-2. Add new `.py` implementation in `libs/ktem/ktem/reasoning/` and later include it in `flowssettings` to enable it on the UI.
+2. Add new `.py` implementation in `libs/ktem/ktem/reasoning/` and later include it in `flowsettings` to enable it on the UI.
 
 #### Custom Indexing Pipeline
 

--- a/docs/pages/app/customize-flows.md
+++ b/docs/pages/app/customize-flows.md
@@ -193,7 +193,7 @@ information panel.
 You can access users' collections of LLMs and embedding models with:
 
 ```python
-from ktem.embeddings.manager import embeddings
+from ktem.embeddings.manager import embedding_models_manager as embeddings
 from ktem.llms.manager import llms
 
 
@@ -213,7 +213,7 @@ models they want to use through the settings.
             "citation_llm": {
                 "name": "LLM for citation",
                 "value": llms.get_default(),
-                "component: "dropdown",
+                "component": "dropdown",
                 "choices": list(llms.options().keys()),
             },
             ...

--- a/libs/kotaemon/kotaemon/embeddings/langchain_based.py
+++ b/libs/kotaemon/kotaemon/embeddings/langchain_based.py
@@ -8,7 +8,7 @@ from .base import BaseEmbeddings
 class LCEmbeddingMixin:
     def _get_lc_class(self):
         raise NotImplementedError(
-            "Please return the relevant Langchain class in in _get_lc_class"
+            "Please return the relevant Langchain class in _get_lc_class"
         )
 
     def __init__(self, **params):

--- a/libs/kotaemon/kotaemon/llms/chats/langchain_based.py
+++ b/libs/kotaemon/kotaemon/llms/chats/langchain_based.py
@@ -15,7 +15,7 @@ class LCChatMixin:
 
     def _get_lc_class(self):
         raise NotImplementedError(
-            "Please return the relevant Langchain class in in _get_lc_class"
+            "Please return the relevant Langchain class in _get_lc_class"
         )
 
     def _get_tool_call_kwargs(self):

--- a/libs/kotaemon/kotaemon/llms/completions/langchain_based.py
+++ b/libs/kotaemon/kotaemon/llms/completions/langchain_based.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class LCCompletionMixin:
     def _get_lc_class(self):
         raise NotImplementedError(
-            "Please return the relevant Langchain class in in _get_lc_class"
+            "Please return the relevant Langchain class in _get_lc_class"
         )
 
     def __init__(self, **params):

--- a/libs/kotaemon/kotaemon/loaders/base.py
+++ b/libs/kotaemon/kotaemon/loaders/base.py
@@ -71,7 +71,7 @@ class LIReaderMixin(BaseComponent):
 
     def _get_wrapped_class(self) -> Type["LIBaseReader"]:
         raise NotImplementedError(
-            "Please return the relevant llama-index class in in _get_wrapped_class"
+            "Please return the relevant llama-index class in _get_wrapped_class"
         )
 
     def __init__(self, *args, **kwargs):

--- a/libs/kotaemon/kotaemon/storages/vectorstores/base.py
+++ b/libs/kotaemon/kotaemon/storages/vectorstores/base.py
@@ -79,7 +79,7 @@ class LlamaIndexVectorStore(BaseVectorStore):
 
     def _get_li_class(self):
         raise NotImplementedError(
-            "Please return the relevant LlamaIndex class in in _get_li_class"
+            "Please return the relevant LlamaIndex class in _get_li_class"
         )
 
     def __init__(self, *args, **kwargs):

--- a/libs/ktem/ktem/embeddings/ui.py
+++ b/libs/ktem/ktem/embeddings/ui.py
@@ -358,7 +358,7 @@ class EmbeddingManagement(BasePage):
             emb = deserialize(info["spec"], safe=False)
 
             if emb is None:
-                raise Exception(f"Can not found model: {selected_emb_name}")
+                raise Exception(f"Cannot find model: {selected_emb_name}")
 
             log_content += "- Sending a message `Hi`<br>"
             yield log_content

--- a/libs/ktem/ktem/index/file/ui.py
+++ b/libs/ktem/ktem/index/file/ui.py
@@ -1272,7 +1272,7 @@ class FileIndexPage(BasePage):
         n_successes = len([_ for _ in results if _])
         if n_successes:
             gr.Info(f"Successfully index {n_successes} files")
-        n_errors = len([_ for _ in errors if _])
+        n_errors = len([_ for _ in index_errors if _])
         if n_errors:
             gr.Warning(f"Have errors for {n_errors} files")
 

--- a/libs/ktem/ktem/llms/ui.py
+++ b/libs/ktem/ktem/llms/ui.py
@@ -358,7 +358,7 @@ class LLMManagement(BasePage):
             llm = deserialize(info["spec"], safe=False)
 
             if llm is None:
-                raise Exception(f"Can not found model: {selected_llm_name}")
+                raise Exception(f"Cannot find model: {selected_llm_name}")
 
             log_content += "- Sending a message `Hi`<br>"
             yield log_content

--- a/libs/ktem/ktem/rerankings/ui.py
+++ b/libs/ktem/ktem/rerankings/ui.py
@@ -357,7 +357,7 @@ class RerankingManagement(BasePage):
             rerank = deserialize(info["spec"], safe=False)
 
             if rerank is None:
-                raise Exception(f"Can not found model: {selected_rerank_name}")
+                raise Exception(f"Cannot find model: {selected_rerank_name}")
 
             log_content += "- Sending a message ([`Hello`], `Hi`)<br>"
             yield log_content
@@ -369,7 +369,7 @@ class RerankingManagement(BasePage):
             )
             yield log_content
 
-            gr.Info(f"Embedding {selected_rerank_name} connect successfully")
+            gr.Info(f"Reranking model {selected_rerank_name} connect successfully")
         except Exception as e:
             print(e)
             log_content += (

--- a/scripts/run_linux.sh
+++ b/scripts/run_linux.sh
@@ -24,8 +24,8 @@ function install_miniconda() {
     # if miniconda has not been installed, download and install it
     if ! "${conda_root}/bin/conda" --version &>/dev/null; then
         if [ ! -d "$install_dir/miniconda_installer.sh" ]; then
-            echo "Downloading Miniconda from $miniconda_url"
             local miniconda_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${sys_arch}.sh"
+            echo "Downloading Miniconda from $miniconda_url"
 
             mkdir -p "$install_dir"
             curl -Lk "$miniconda_url" >"$install_dir/miniconda_installer.sh"


### PR DESCRIPTION
## Summary

### Functional fixes
- **`libs/ktem/ktem/index/file/ui.py`**: after unpacking `results, index_errors, docs`, `n_errors` counted the stale pre-flight `errors` list — which is guaranteed empty at that point (the function returns early `if errors:`) — so the `Have errors for N files` warning **never fired** even when files failed to index. Now counts `index_errors`.
- **`rerankings/ui.py`**: the connection-test toast said "Embedding … connect successfully" (copy-pasted from `embeddings/ui.py`); now says "Reranking model …".
- **`scripts/run_linux.sh`**: echoed `$miniconda_url` before assigning it (printed an empty URL); swapped the lines to match `run_macos.sh`.

### Docs
- `docs/pages/app/customize-flows.md`: malformed `"component: "dropdown",` dict entry (SyntaxError if copied) → `"component": "dropdown",`; `from ktem.embeddings.manager import embeddings` → `import embedding_models_manager as embeddings` (the module exports only `embedding_models_manager`).
- `README.md`: `flowssettings` → `flowsettings`.

### Minor
- doubled "in in" in five `NotImplementedError` messages; `Can not found model` → `Cannot find model` in three parallel UI files.