### PR TITLE
fix(retrieval): deduplicate hybrid results by document ID

### DIFF
--- a/libs/kotaemon/kotaemon/indices/vectorindex.py
+++ b/libs/kotaemon/kotaemon/indices/vectorindex.py
@@ -224,10 +224,11 @@ class VectorRetrieval(BaseRetrieval):
             vs_query_thread.join()
             ds_query_thread.join()
 
+            vs_id_set = set(vs_ids)
             result = [
                 RetrievedDocument(**doc.to_dict(), score=-1.0)
                 for doc in ds_docs
-                if doc not in vs_ids
+                if doc.doc_id not in vs_id_set
             ]
             result += [
                 RetrievedDocument(**doc.to_dict(), score=score)

--- a/libs/kotaemon/tests/test_indexing_retrieval.py
+++ b/libs/kotaemon/tests/test_indexing_retrieval.py
@@ -1,17 +1,45 @@
 import json
 from pathlib import Path
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from openai.types.create_embedding_response import CreateEmbeddingResponse
 
-from kotaemon.base import Document
-from kotaemon.embeddings import AzureOpenAIEmbeddings
+from kotaemon.base import Document, DocumentWithEmbedding
+from kotaemon.embeddings import AzureOpenAIEmbeddings, BaseEmbeddings
 from kotaemon.indices import VectorIndexing, VectorRetrieval
 from kotaemon.storages import ChromaVectorStore, InMemoryDocumentStore
 
 with open(Path(__file__).parent / "resources" / "embedding_openai.json") as f:
     openai_embedding = CreateEmbeddingResponse.model_validate(json.load(f))
+
+
+class _FakeEmbeddings(BaseEmbeddings):
+    def invoke(self, text, *args, **kwargs):
+        return [DocumentWithEmbedding(embedding=[1.0])]
+
+
+def _run_hybrid_retrieval(text_ids, vector_ids, vector_scores):
+    docs = {
+        doc_id: Document(text=f"text {doc_id}", id_=doc_id)
+        for doc_id in set(text_ids + vector_ids)
+    }
+
+    vector_store = Mock()
+    vector_store.query.return_value = ([], vector_scores, vector_ids)
+
+    doc_store = Mock()
+    doc_store.query.return_value = [docs[doc_id] for doc_id in text_ids]
+    doc_store.get.side_effect = lambda ids: [docs[doc_id] for doc_id in ids]
+
+    pipeline = VectorRetrieval(
+        vector_store=vector_store,
+        doc_store=doc_store,
+        embedding=_FakeEmbeddings(),
+        retrieval_mode="hybrid",
+        rerankers=[],
+    )
+    return pipeline(text="query", top_k=10, scope=list(docs))
 
 
 @patch(
@@ -65,3 +93,21 @@ def test_retrieving(tmp_path):
 
     assert len(output) == 1, "Expect 1 results"
     assert output == output1, "Expect identical results"
+
+
+def test_hybrid_retrieval_deduplicates_overlapping_documents():
+    output = _run_hybrid_retrieval(
+        text_ids=["A", "B"], vector_ids=["A", "C"], vector_scores=[0.91, 0.73]
+    )
+
+    assert [doc.doc_id for doc in output] == ["B", "A", "C"]
+    assert len({doc.doc_id for doc in output}) == len(output)
+    assert next(doc for doc in output if doc.doc_id == "A").score == 0.91
+
+
+def test_hybrid_retrieval_keeps_disjoint_documents():
+    output = _run_hybrid_retrieval(
+        text_ids=["A", "B"], vector_ids=["C", "D"], vector_scores=[0.82, 0.64]
+    )
+
+    assert [doc.doc_id for doc in output] == ["A", "B", "C", "D"]


### PR DESCRIPTION
## Description

- Deduplicate overlapping text and vector retrieval results by document ID.
- Retain the vector-retrieved document and its similarity score when both retrieval paths return the same document.
- Add regression tests for overlapping and non-overlapping hybrid retrieval results.
- Fixes #858

## Type of change

- [ ] New features (non-breaking change).
- [x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if it is a core feature.
- [x] There is a reference to the original bug report and related work.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] The feature is well documented.
