### PR TITLE
feat(retrievers): add Keenable web search backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ PDFJS_VERSION_DIST="pdfjs-4.0.379-dist"
 # settings for PaddleOCR
 PADDLE_DEVICE=gpu
 
+# settings for web search (see KH_WEB_SEARCH_BACKEND in flowsettings.py)
+# TAVILY_API_KEY=
+# JINA_API_KEY=
+# Keenable works without a key; setting one only lifts the rate limits
+# KEENABLE_API_KEY=
+
 # variable for authentication method selection
 # for authentication with google leave empty
 # for authentication with keycloak :

--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ KH_VECTORSTORE=(ChromaDB | LanceDB | InMemory | Milvus | Qdrant)
 # Enable / disable multimodal QA
 KH_REASONINGS_USE_MULTIMODAL=True
 
+# setup the backend for the @WebSearch chat command
+# (Tavily and Jina need an API key; Keenable works without one)
+KH_WEB_SEARCH_BACKEND=(
+    "kotaemon.indices.retrievers.tavily_web_search.WebSearch"
+    | "kotaemon.indices.retrievers.jina_web_search.WebSearch"
+    | "kotaemon.indices.retrievers.keenable_web_search.WebSearch"
+)
+
 # Setup your new reasoning pipeline or modify existing one.
 KH_REASONINGS = [
     "ktem.reasoning.simple.FullQAPipeline",

--- a/flowsettings.py
+++ b/flowsettings.py
@@ -87,6 +87,8 @@ KH_FILESTORAGE_PATH = str(KH_USER_DATA_DIR / "files")
 KH_WEB_SEARCH_BACKEND = (
     "kotaemon.indices.retrievers.tavily_web_search.WebSearch"
     # "kotaemon.indices.retrievers.jina_web_search.WebSearch"
+    # works without an API key; KEENABLE_API_KEY only lifts the rate limits
+    # "kotaemon.indices.retrievers.keenable_web_search.WebSearch"
 )
 
 KH_DOCSTORE = {

--- a/libs/kotaemon/kotaemon/indices/retrievers/keenable_web_search.py
+++ b/libs/kotaemon/kotaemon/indices/retrievers/keenable_web_search.py
@@ -1,0 +1,102 @@
+import requests
+from decouple import config
+
+from kotaemon.base import BaseComponent, Param, RetrievedDocument
+
+KEENABLE_API_KEY = config("KEENABLE_API_KEY", default="")
+KEENABLE_API_BASE = config("KEENABLE_API_BASE", default="https://api.keenable.ai")
+
+# Sent on every request so Keenable can attribute traffic to the app.
+# Mandatory on keyless calls.
+KEENABLE_APP_TITLE = "kotaemon"
+
+
+class WebSearch(BaseComponent):
+    """WebSearch component for fetching data from the web
+    using the Keenable search API (https://keenable.ai)
+
+    Works without an API key through the public endpoint. Setting
+    `KEENABLE_API_KEY` switches to the authenticated endpoint, which only
+    lifts the rate limits.
+    """
+
+    max_results: int = Param(10, help="Number of search results to fetch (1 to 50)")
+    snippet_max_length: int = Param(
+        2000,
+        help=(
+            "Approximate maximum length in characters of the page text "
+            "returned for each result"
+        ),
+    )
+    timeout: int = Param(30, help="HTTP timeout in seconds")
+
+    def _search(self, query: str) -> list[dict]:
+        headers = {
+            "Content-Type": "application/json",
+            "X-Keenable-Title": KEENABLE_APP_TITLE,
+        }
+        if KEENABLE_API_KEY:
+            api_url = f"{KEENABLE_API_BASE}/v1/search"
+            headers["X-API-Key"] = KEENABLE_API_KEY
+        else:
+            api_url = f"{KEENABLE_API_BASE}/v1/search/public"
+
+        payload = {
+            "query": query,
+            "max_results": self.max_results,
+            "snippet_max_length": self.snippet_max_length,
+        }
+
+        response = requests.post(
+            api_url, json=payload, headers=headers, timeout=self.timeout
+        )
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            try:
+                retry_after = response.json().get("retryAfter", retry_after)
+            except ValueError:
+                pass
+            hint = (
+                "set KEENABLE_API_KEY to lift the limit"
+                if not KEENABLE_API_KEY
+                else "try again later"
+            )
+            raise RuntimeError(
+                "Keenable web search rate limit exceeded "
+                f"(retry after {retry_after} seconds); {hint}"
+            )
+        response.raise_for_status()
+
+        return response.json().get("results", [])
+
+    def run(
+        self,
+        text: str,
+        *args,
+        **kwargs,
+    ) -> list[RetrievedDocument]:
+        results = self._search(text)
+
+        context = "\n\n".join(
+            "###URL: [{url}]({url})\n\n####{title}\n\n{content}".format(
+                url=result.get("url", ""),
+                title=result.get("title", ""),
+                # `snippet` carries the page text; `description` is usually empty
+                content=result.get("snippet") or result.get("description") or "",
+            )
+            for result in results
+        )
+
+        return [
+            RetrievedDocument(
+                text=context,
+                metadata={
+                    "file_name": "Web search",
+                    "type": "table",
+                    "llm_trulens_score": 1.0,
+                },
+            )
+        ]
+
+    def generate_relevant_scores(self, text, documents: list[RetrievedDocument]):
+        return documents

--- a/libs/kotaemon/tests/test_web_search.py
+++ b/libs/kotaemon/tests/test_web_search.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from kotaemon.base import RetrievedDocument
+from kotaemon.indices.retrievers import keenable_web_search
+from kotaemon.indices.retrievers.keenable_web_search import WebSearch
+
+KEENABLE_RESPONSE = {
+    "query": "Cinnamon AI",
+    "results": [
+        {
+            "title": "Cinnamon AI",
+            "url": "https://www.cinnamon.is/en/",
+            "description": "",
+            "snippet": "Cinnamon AI is an enterprise AI company.",
+            "acquired_at": "2026-09-01T00:00:00Z",
+        },
+        {
+            "title": "kotaemon",
+            "url": "https://github.com/Cinnamon/kotaemon",
+            "description": "An open-source RAG UI.",
+            "snippet": "",
+            "acquired_at": "2026-09-01T00:00:00Z",
+        },
+    ],
+}
+
+
+def _mock_response(status_code=200, json_data=None, headers=None):
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.json.return_value = json_data if json_data is not None else {}
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"{status_code} error"
+        )
+    return response
+
+
+@patch("kotaemon.indices.retrievers.keenable_web_search.requests.post")
+def test_keenable_web_search_keyless(mock_post, monkeypatch):
+    monkeypatch.setattr(keenable_web_search, "KEENABLE_API_KEY", "")
+    mock_post.return_value = _mock_response(json_data=KEENABLE_RESPONSE)
+
+    documents = WebSearch(max_results=5)("Cinnamon AI")
+
+    mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    assert mock_post.call_args[0][0].endswith("/v1/search/public")
+    assert kwargs["headers"]["X-Keenable-Title"] == "kotaemon"
+    assert "X-API-Key" not in kwargs["headers"]
+    assert kwargs["json"] == {
+        "query": "Cinnamon AI",
+        "max_results": 5,
+        "snippet_max_length": 2000,
+    }
+
+    assert len(documents) == 1
+    assert isinstance(documents[0], RetrievedDocument)
+    assert documents[0].metadata["file_name"] == "Web search"
+    # page text comes from `snippet`, falling back to `description`
+    assert "https://www.cinnamon.is/en/" in documents[0].text
+    assert "Cinnamon AI is an enterprise AI company." in documents[0].text
+    assert "An open-source RAG UI." in documents[0].text
+
+
+@patch("kotaemon.indices.retrievers.keenable_web_search.requests.post")
+def test_keenable_web_search_with_api_key(mock_post, monkeypatch):
+    monkeypatch.setattr(keenable_web_search, "KEENABLE_API_KEY", "test-key")
+    mock_post.return_value = _mock_response(json_data=KEENABLE_RESPONSE)
+
+    WebSearch()("Cinnamon AI")
+
+    _, kwargs = mock_post.call_args
+    assert mock_post.call_args[0][0].endswith("/v1/search")
+    assert kwargs["headers"]["X-API-Key"] == "test-key"
+    assert kwargs["headers"]["X-Keenable-Title"] == "kotaemon"
+
+
+@patch("kotaemon.indices.retrievers.keenable_web_search.requests.post")
+def test_keenable_web_search_rate_limited(mock_post, monkeypatch):
+    monkeypatch.setattr(keenable_web_search, "KEENABLE_API_KEY", "")
+    mock_post.return_value = _mock_response(
+        status_code=429,
+        json_data={
+            "error": "Rate limit exceeded",
+            "message": "Too many requests",
+            "retryAfter": 7,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="rate limit exceeded.*7"):
+        WebSearch()("Cinnamon AI")


### PR DESCRIPTION
## Description

Adds `kotaemon.indices.retrievers.keenable_web_search.WebSearch` as a third option for `KH_WEB_SEARCH_BACKEND`, next to the Tavily and Jina retrievers.

The difference from the two existing backends is that it works without an API key. With no `KEENABLE_API_KEY` set it calls the public endpoint (`POST https://api.keenable.ai/v1/search/public`); setting a key switches to the authenticated endpoint and only lifts the rate limits. So the `@WebSearch` chat command can work on a fresh install.

The module follows the shape of `tavily_web_search.py`:

- same class name and module layout, so the dotted-string setting works unchanged;
- one `RetrievedDocument` with the results concatenated as URL / title / page text, and the same `file_name` / `type` / `llm_trulens_score` metadata the reasoning pipelines expect;
- `max_results`, `snippet_max_length` and `timeout` exposed as `Param`s;
- a 429 from the API raises a `RuntimeError` with the retry-after value.

It uses `requests`, which the package already imports elsewhere; no new dependencies.

Also documented: the new option is listed (commented) in `flowsettings.py`, `.env.example` gains a web-search block with the three key variables, and `README.md` mentions `KH_WEB_SEARCH_BACKEND` under notable settings. Tavily stays the default.

Tested with `libs/kotaemon/tests/test_web_search.py` (mocked `requests.post`: keyless endpoint and headers, keyed endpoint, 429 handling), `pre-commit` on the changed files, and a live keyless query through the retriever.

Disclosure: I work at Keenable.

## Type of change

- [x] New features (non-breaking change).
- [ ] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if it is a core feature.
- [ ] There is a reference to the original bug report and related work.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] The feature is well documented.
